### PR TITLE
Remove loading indicator on screen transitions

### DIFF
--- a/lib/pages/calendar_page.dart
+++ b/lib/pages/calendar_page.dart
@@ -40,9 +40,7 @@ class _CalendarPageState extends State<CalendarPage> {
   @override
   Widget build(BuildContext context) => Center(
         child: SingleChildScrollView(
-          child: isLoading
-              ? const CircularProgressIndicator()
-              : buildEntries(context),
+          child: isLoading ? const SizedBox() : buildEntries(context),
         ),
       );
 

--- a/lib/pages/entries_page.dart
+++ b/lib/pages/entries_page.dart
@@ -62,7 +62,7 @@ class _EntriesPageState extends State<EntriesPage> {
   @override
   Widget build(BuildContext context) => Center(
         child: isLoading
-            ? const CircularProgressIndicator()
+            ? const SizedBox()
             : Stack(alignment: Alignment.topCenter, children: [
                 buildEntries(),
                 Column(

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -80,7 +80,7 @@ class _HomePageState extends State<HomePage> {
   @override
   Widget build(BuildContext context) => Center(
         child: isLoading
-            ? const CircularProgressIndicator()
+            ? const SizedBox()
             : Stack(alignment: Alignment.bottomCenter, children: [
                 buildEntries(),
                 Column(

--- a/lib/widgets/entry_day_cell.dart
+++ b/lib/widgets/entry_day_cell.dart
@@ -51,10 +51,7 @@ class _EntryDayCellState extends State<EntryDayCell> {
                   height: 16,
                 ),
                 isLoading
-                    ? Icon(
-                        Icons.add_rounded,
-                        color: Theme.of(context).disabledColor,
-                      )
+                    ? const SizedBox()
                     : entry != null
                         ? MoodIcon(moodValue: entry!.mood)
                         : Icon(


### PR DESCRIPTION
Remove loading indicator on screen transitions
Mood icon won't appear until it is known to prevent flicker

closes #25 