### PR TITLE
Fix notification not dismissing

### DIFF
--- a/lib/notification_manager.dart
+++ b/lib/notification_manager.dart
@@ -50,6 +50,7 @@ class NotificationManager {
 
   Future<void> stopDailyReminders() async {
     await AndroidAlarmManager.cancel(0);
+    await NotificationManager.instance.notifications.cancel(0);
   }
 
   Future<void> startScheduledDailyReminders() async {

--- a/lib/pages/edit_entry_page.dart
+++ b/lib/pages/edit_entry_page.dart
@@ -1,3 +1,4 @@
+import 'package:daily_you/notification_manager.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:daily_you/entries_database.dart';
@@ -204,6 +205,7 @@ class _AddEditEntryPageState extends State<AddEditEntryPage> {
       timeModified: DateTime.now(),
     );
 
+    await NotificationManager.instance.notifications.cancel(0);
     var entry = await EntriesDatabase.instance.create(newEntry);
 
     Navigator.of(context).pop(entry);

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -90,7 +90,9 @@ class _HomePageState extends State<HomePage> {
     var launchDetails = await NotificationManager.instance.notifications
         .getNotificationAppLaunchDetails();
     if (NotificationManager.instance.justLaunched &&
-        launchDetails?.notificationResponse?.id == 0) {
+        launchDetails?.notificationResponse?.id == 0 &&
+        await EntriesDatabase.instance.getEntryForDate(DateTime.now()) ==
+            null) {
       NotificationManager.instance.justLaunched = false;
       await logToday();
     }


### PR DESCRIPTION
The daily reminder notification can no longer be used to make multiple entries in a day. The notification will now also dismiss when the app is opened. 

closes #47 