### PR TITLE
Allow for legacy storage permissions

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.demizo.daily_you">
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="32"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -22,6 +22,30 @@ class SettingsPage extends StatefulWidget {
 }
 
 class _SettingsPageState extends State<SettingsPage> {
+  Future<bool> requestStoragePermission() async {
+    var hasPermission = false;
+
+    //Legacy Permission
+    var status = await Permission.storage.status;
+    if (!status.isGranted) {
+      status = await Permission.storage.request();
+    }
+    if (status.isGranted) {
+      hasPermission = true;
+    }
+
+    //Modern Permission
+    status = await Permission.manageExternalStorage.status;
+    if (!status.isGranted && hasPermission == false) {
+      status = await Permission.manageExternalStorage.request();
+    }
+    if (status.isGranted) {
+      hasPermission = true;
+    }
+
+    return hasPermission;
+  }
+
   void _showThemeSelectionPopup(ThemeModeProvider themeModeProvider) {
     showDialog(
       context: context,
@@ -659,12 +683,9 @@ class _SettingsPageState extends State<SettingsPage> {
                       ),
                       label: const Text("Change Log Folder..."),
                       onPressed: () async {
-                        if (Platform.isAndroid) {
-                          var status =
-                              await Permission.manageExternalStorage.request();
-                          if (status.isDenied || status.isPermanentlyDenied) {
-                            return;
-                          }
+                        if (Platform.isAndroid &&
+                            !await requestStoragePermission()) {
+                          return;
                         }
                         await EntriesDatabase.instance.selectDatabaseLocation();
                         setState(() {});
@@ -708,12 +729,9 @@ class _SettingsPageState extends State<SettingsPage> {
                       ),
                       label: const Text("Change Image Folder..."),
                       onPressed: () async {
-                        if (Platform.isAndroid) {
-                          var status =
-                              await Permission.manageExternalStorage.request();
-                          if (status.isDenied || status.isPermanentlyDenied) {
-                            return;
-                          }
+                        if (Platform.isAndroid &&
+                            !await requestStoragePermission()) {
+                          return;
                         }
                         await EntriesDatabase.instance.selectImageFolder();
                         setState(() {});
@@ -749,12 +767,9 @@ class _SettingsPageState extends State<SettingsPage> {
                       ),
                       label: const Text("Export Logs..."),
                       onPressed: () async {
-                        if (Platform.isAndroid) {
-                          var status =
-                              await Permission.manageExternalStorage.request();
-                          if (status.isDenied || status.isPermanentlyDenied) {
-                            return;
-                          }
+                        if (Platform.isAndroid &&
+                            !await requestStoragePermission()) {
+                          return;
                         }
                         _showExportSelectionPopup();
                       },
@@ -768,12 +783,9 @@ class _SettingsPageState extends State<SettingsPage> {
                       ),
                       label: const Text("Export Images..."),
                       onPressed: () async {
-                        if (Platform.isAndroid) {
-                          var status =
-                              await Permission.manageExternalStorage.request();
-                          if (status.isDenied || status.isPermanentlyDenied) {
-                            return;
-                          }
+                        if (Platform.isAndroid &&
+                            !await requestStoragePermission()) {
+                          return;
                         }
                         await EntriesDatabase.instance.exportImages();
                       },
@@ -801,12 +813,9 @@ class _SettingsPageState extends State<SettingsPage> {
                       ),
                       label: const Text("Import Logs..."),
                       onPressed: () async {
-                        if (Platform.isAndroid) {
-                          var status =
-                              await Permission.manageExternalStorage.request();
-                          if (status.isDenied || status.isPermanentlyDenied) {
-                            return;
-                          }
+                        if (Platform.isAndroid &&
+                            !await requestStoragePermission()) {
+                          return;
                         }
                         _showImportSelectionPopup();
                       },
@@ -820,12 +829,9 @@ class _SettingsPageState extends State<SettingsPage> {
                       ),
                       label: const Text("Import Images..."),
                       onPressed: () async {
-                        if (Platform.isAndroid) {
-                          var status =
-                              await Permission.manageExternalStorage.request();
-                          if (status.isDenied || status.isPermanentlyDenied) {
-                            return;
-                          }
+                        if (Platform.isAndroid &&
+                            !await requestStoragePermission()) {
+                          return;
                         }
                         await EntriesDatabase.instance.importImages();
                       },


### PR DESCRIPTION
Add legacy storage permissions for older versions of android. 
Known issue: SD card can't be accessed on android 8.
closes #65 