### PR TITLE
Fix uri over reboot

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
     "java.configuration.updateBuildConfiguration": "interactive",
     "cSpell.words": [
         "Appimage",
-        "curr"
+        "curr",
+        "persistable"
     ]
 }

--- a/lib/entries_database.dart
+++ b/lib/entries_database.dart
@@ -245,6 +245,16 @@ CREATE TABLE $entriesTable (
     return join(basePath.path, 'daily_you.db');
   }
 
+  // Ensure external folders can be accessed if in use
+  Future<bool> hasDbUriPermission() async {
+    return FileLayer.hasPermission(
+        await ConfigManager.instance.getField('externalDbUri'));
+  }
+
+  Future<bool> hasImgUriPermission() async {
+    return FileLayer.hasPermission(await getExternalImgDatabasePath());
+  }
+
   Future<bool> selectDatabaseLocation() async {
     StatsProvider.instance.updateSyncStats(0, 0);
     var selectedDirectory = await FileLayer.pickDirectory();

--- a/lib/file_layer.dart
+++ b/lib/file_layer.dart
@@ -40,6 +40,19 @@ class FileLayer {
     }
   }
 
+  static Future<bool> hasPermission(String uri) async {
+    if (Platform.isAndroid) {
+      if (await saf.exists(Uri.parse(uri)) == true &&
+          await saf.canWrite(Uri.parse(uri)) == true) {
+        return true;
+      } else {
+        return false;
+      }
+    } else {
+      return await Directory(uri).exists();
+    }
+  }
+
   static Future<Uint8List?> getFileBytes(String uri,
       {String? name, bool useExternalPath = true}) async {
     if (Platform.isAndroid && useExternalPath) {

--- a/lib/file_layer.dart
+++ b/lib/file_layer.dart
@@ -25,7 +25,8 @@ class FileLayer {
   static Future<String?> pickFile() async {
     if (Platform.isAndroid) {
       // Android
-      var selectedFile = await saf.openDocument();
+      var selectedFile = await saf.openDocument(
+          grantWritePermission: false, persistablePermission: false);
       if (selectedFile == null) return null;
       return selectedFile.first.toString();
     } else {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -583,11 +583,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: HEAD
-      resolved-ref: df4f4855c63e27d94e5066d68044cc345cf1df8d
+      ref: release
+      resolved-ref: "789927b69de53bb4dbe5b4b803da0e5944f9bf40"
       url: "https://github.com/Demizo/shared-storage"
     source: git
-    version: "0.7.0"
+    version: "0.8.0"
   simple_gesture_detector:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
   shared_storage:
     git:
       url: https://github.com/Demizo/shared-storage
+      ref: release
   device_info_plus: ^9.1.1
   fl_chart: ^0.66.0
 


### PR DESCRIPTION
Fixes URI permissions being lost after device reboot. Warn user then a folder URI can't be reached instead of silently failing.

closes #81 