### PR TITLE
Use the correct external image name

### DIFF
--- a/lib/entries_database.dart
+++ b/lib/entries_database.dart
@@ -182,7 +182,8 @@ CREATE TABLE $entriesTable (
     final newImageName =
         "daily_you_${currTime.month}_${currTime.day}_${currTime.year}-${currTime.hour}.${currTime.minute}.${currTime.second}.jpg";
     if (usingExternalImg()) {
-      FileLayer.createFile(await getExternalImgDatabasePath(), imageName, bytes,
+      FileLayer.createFile(
+          await getExternalImgDatabasePath(), newImageName, bytes,
           useExternalPath: true); //Background
     }
     var imageFilePath = await FileLayer.createFile(


### PR DESCRIPTION
Fix: Use the correct image name when saving the image externally. The internal image name was correct. This means that if you clear internal storage it will appear like the image is missing externally when it is not. Fix ASAP to avoid future confusion.

closes #82 