### PR TITLE
Fix: Image import frozen

### DIFF
--- a/fastlane/metadata/android/de/changelogs/201.txt
+++ b/fastlane/metadata/android/de/changelogs/201.txt
@@ -1,4 +1,4 @@
-Daily You v2.0.1 ist da! Hier sind die Änderungen:
+Daily You v2.0.1 ist da!
 
 HINWEIS: Wenn Sie einen externen Bildspeicherort verwenden und Fotos mit v2.0.0 aufgenommen haben, lesen Sie in den Github-Versionshinweisen nach, wie Sie die Bildnamen korrigieren können!
 

--- a/lib/entries_database.dart
+++ b/lib/entries_database.dart
@@ -520,9 +520,12 @@ CREATE TABLE $entriesTable (
     final picker = ImagePicker();
     final pickedFiles = await picker.pickMultiImage();
 
-    List<String> externalImages = await FileLayer.listFiles(
-        await getExternalImgDatabasePath(),
-        useExternalPath: true);
+    List<String> externalImages = List.empty(growable: true);
+    if (usingExternalDb()) {
+      externalImages.addAll(await FileLayer.listFiles(
+          await getExternalImgDatabasePath(),
+          useExternalPath: true));
+    }
     List<String> internalImages = await FileLayer.listFiles(
         await getInternalImgDatabasePath(),
         useExternalPath: false);

--- a/lib/entries_database.dart
+++ b/lib/entries_database.dart
@@ -521,7 +521,7 @@ CREATE TABLE $entriesTable (
     final pickedFiles = await picker.pickMultiImage();
 
     List<String> externalImages = List.empty(growable: true);
-    if (usingExternalDb()) {
+    if (usingExternalImg()) {
       externalImages.addAll(await FileLayer.listFiles(
           await getExternalImgDatabasePath(),
           useExternalPath: true));


### PR DESCRIPTION
Image import was freezing when an external image folder was not in use. This was because the import sequence was attempting to list files in an external directory that either didn't exist or it didn't have permissions for. External files should not be checked when an external image folder is not in use.

closes #80 