### PR TITLE
Fix notifications not sending

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,6 +16,8 @@ import 'package:provider/provider.dart';
 
 @pragma('vm:entry-point')
 void callbackDispatcher() async {
+  await ConfigManager.instance.init();
+  await EntriesDatabase.instance.initDB();
   if (await EntriesDatabase.instance.getEntryForDate(DateTime.now()) == null) {
     FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
         FlutterLocalNotificationsPlugin();
@@ -41,7 +43,7 @@ void callbackDispatcher() async {
     await flutterLocalNotificationsPlugin.show(
         0, 'Log Today!', 'Take your daily log...', platformChannelSpecifics);
   }
-  await ConfigManager.instance.init();
+  EntriesDatabase.instance.close();
   Duration timeUntilReminder;
   DateTime dayToRemind = TimeManager.startOfNextDay();
   DateTime reminderDateTime = TimeManager.addTimeOfDay(


### PR DESCRIPTION
With the change to SAF the database needs to be initialized before use. The notification service was crashing and not sending notifications since the database was not initialized.

For good measure, schedule exact alarm permission is also requested when relevant.

closes #90 