### PR TITLE
feat: allow use of the local db when offline 

### DIFF
--- a/lib/entries_database.dart
+++ b/lib/entries_database.dart
@@ -22,8 +22,15 @@ class EntriesDatabase {
 
   EntriesDatabase._init();
 
-  Future<bool> initDB() async {
-    if (usingExternalDb()) await syncDatabase();
+  Future<bool> initDB({bool forceWithoutSync = false}) async {
+    if (usingExternalDb() && !forceWithoutSync) {
+      if (await hasDbUriPermission()) {
+        await syncDatabase();
+      } else {
+        return false;
+      }
+    }
+
     final dbPath = await getInternalDbPath();
 
     _database = await openDatabase(dbPath,


### PR DESCRIPTION
Previously, the app would hang when:
- A network storage location was used and the device was offline
- A external storage location was used and permissions were lost

Now the user can continue with the local database copy.