### PR TITLE
feat: support per app language on android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,7 +9,8 @@
         android:label="Daily You"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
-		android:roundIcon="@mipmap/ic_launcher_rounded">
+	android:roundIcon="@mipmap/ic_launcher_rounded"
+	android:localeConfig="@xml/locales_config">
         <service
             android:name="dev.fluttercommunity.plus.androidalarmmanager.AlarmService"
             android:permission="android.permission.BIND_JOB_SERVICE"

--- a/android/app/src/main/res/xml/locales_config.xml
+++ b/android/app/src/main/res/xml/locales_config.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+  <locale android:name="en" />
+  <locale android:name="de" />
+  <locale android:name="es" />
+  <locale android:name="fr" />
+  <locale android:name="id" />
+  <locale android:name="ru" />
+  <locale android:name="tr" />
+  <locale android:name="vi" />
+  <locale android:name="zh" />
+  <locale android:name="zh-Hant" />
+</locale-config>


### PR DESCRIPTION
Adds support for setting a preferred locale for the Daily You app rather than always following the system default

closes #149 