### PR TITLE
fix: fallback to english

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -170,7 +170,11 @@ class _MainAppState extends State<MainApp> {
             themeMode: themeModeProvider.themeMode,
             debugShowCheckedModeBanner: false,
             localizationsDelegates: AppLocalizations.localizationsDelegates,
-            supportedLocales: AppLocalizations.supportedLocales,
+            supportedLocales: [
+              Locale("en"),
+              ...AppLocalizations.supportedLocales
+                  .where((locale) => locale.languageCode != "en")
+            ],
             theme: ThemeData(
               useMaterial3: true,
               colorScheme: ColorScheme.fromSeed(


### PR DESCRIPTION
Fallback to English when the device does not support per app locale settings and a matching language is not found.

closes #160 