### PR TITLE
Fix link notification to arrival date

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -57,7 +57,8 @@ void callbackDispatcher() async {
 
     if (title != null && description != null) {
       await flutterLocalNotificationsPlugin.show(
-          0, title, description, platformChannelSpecifics);
+          0, title, description, platformChannelSpecifics,
+          payload: DateTime.now().toIso8601String());
     }
   }
   EntriesDatabase.instance.close();

--- a/lib/time_manager.dart
+++ b/lib/time_manager.dart
@@ -38,6 +38,10 @@ class TimeManager {
         .add(Duration(hours: timeOfDay.hour, minutes: timeOfDay.minute));
   }
 
+  static DateTime currentTimeOnDifferentDate(DateTime targetDate) {
+    return addTimeOfDay(startOfDay(targetDate), TimeOfDay.now());
+  }
+
   static TimeOfDay scheduledReminderTime() {
     return TimeOfDay(
         hour: ConfigProvider.instance.get(ConfigKey.scheduledReminderHour),

--- a/lib/widgets/entry_day_cell.dart
+++ b/lib/widgets/entry_day_cell.dart
@@ -1,6 +1,7 @@
 import 'package:daily_you/config_provider.dart';
 import 'package:daily_you/models/image.dart';
 import 'package:daily_you/stats_provider.dart';
+import 'package:daily_you/time_manager.dart';
 import 'package:daily_you/widgets/local_image_loader.dart';
 import 'package:flutter/material.dart';
 import 'package:daily_you/widgets/mood_icon.dart';
@@ -157,7 +158,8 @@ class EntryDayCell extends StatelessWidget {
           await Navigator.of(context).push(MaterialPageRoute(
             allowSnapshotting: false,
             builder: (context) => AddEditEntryPage(
-              overrideCreateDate: date,
+              overrideCreateDate: TimeManager.currentTimeOnDifferentDate(date)
+                  .copyWith(isUtc: false),
             ),
           ));
         },


### PR DESCRIPTION
- Make notification open the log for the date when it appeared.
- Use the current time of day when adding entries to past days rather than defaulting to hour 0 (12 AM).

closes #215 