### PR TITLE
fix: add Czech to supporting languages

### DIFF
--- a/android/app/src/main/res/xml/locales_config.xml
+++ b/android/app/src/main/res/xml/locales_config.xml
@@ -2,6 +2,7 @@
 <locale-config xmlns:android="http://schemas.android.com/apk/res/android">
   <locale android:name="en" />
   <locale android:name="ar" />
+  <locale android:name="cs" />
   <locale android:name="da" />
   <locale android:name="de" />
   <locale android:name="es" />

--- a/lib/language_option.dart
+++ b/lib/language_option.dart
@@ -14,6 +14,7 @@ class LanguageOption {
   static final displayNameMapping = {
     LanguageOption(languageCode: "en"): "English",
     LanguageOption(languageCode: "ar"): "العربية",
+    LanguageOption(languageCode: "cs"): "čeština",
     LanguageOption(languageCode: "da"): "dansk",
     LanguageOption(languageCode: "de"): "Deutsch",
     LanguageOption(languageCode: "es"): "español",

--- a/lib/pages/settings/language_settings.dart
+++ b/lib/pages/settings/language_settings.dart
@@ -26,7 +26,7 @@ class _LanguageSettingsState extends State<LanguageSettings> {
 
   @override
   Widget build(BuildContext context) {
-    ConfigProvider configProvider = Provider.of(context);
+    ConfigProvider configProvider = Provider.of<ConfigProvider>(context);
     return Scaffold(
       appBar: AppBar(
         title: Text(AppLocalizations.of(context)!.settingsLanguageTitle),


### PR DESCRIPTION
Adds Czech to the supported languages list and fixes the blank language settings page

closes #237 