### PR TITLE
feat: hide log count when the entries have not been filtered

### DIFF
--- a/lib/pages/gallery_page.dart
+++ b/lib/pages/gallery_page.dart
@@ -175,11 +175,13 @@ class _GalleryPageState extends State<GalleryPage> {
                           : SizedBox.shrink(
                               key: ValueKey('empty')), // Empty widget
                     ),
-                    Padding(
-                      padding: const EdgeInsets.only(right: 8.0),
-                      child: Text(AppLocalizations.of(context)!
-                          .logCount(statsProvider.filteredEntries.length)),
-                    ),
+                    if (statsProvider.filteredEntries.length !=
+                        statsProvider.entries.length)
+                      Padding(
+                        padding: const EdgeInsets.only(right: 8.0),
+                        child: Text(AppLocalizations.of(context)!
+                            .logCount(statsProvider.filteredEntries.length)),
+                      ),
                     IconButton(
                         icon: const Icon(Icons.sort_rounded),
                         onPressed: () => _showSortSelectionPopup(context)),


### PR DESCRIPTION
Hide the log count when no log filter is applied. The total log count is still available on the statistics page. This helps to de-clutter the search bar.