### PR TITLE
fix: begin search after a single character

### DIFF
--- a/lib/stats_provider.dart
+++ b/lib/stats_provider.dart
@@ -64,7 +64,7 @@ class StatsProvider with ChangeNotifier {
   SortOrder sortOrder = SortOrder.descending;
 
   List<Entry> filterEntries(List<Entry> entries) {
-    if (searchText.length > 2) {
+    if (searchText.isNotEmpty) {
       entries = entries
           .where((entry) =>
               entry.text.toLowerCase().contains(searchText.toLowerCase()))


### PR DESCRIPTION
The debounce is sufficient to limit rapid search changes. The requirement of at least 3 search characters impacted languages where a single character may represent a full word or phrase.

closes #262 