### PR TITLE
fix: avoid reloading image on every rebuild

### DIFF
--- a/lib/widgets/local_image_loader.dart
+++ b/lib/widgets/local_image_loader.dart
@@ -1,42 +1,72 @@
-import 'dart:typed_data';
 import 'package:daily_you/widgets/local_image_cache.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
-class LocalImageLoader extends StatelessWidget {
+class LocalImageLoader extends StatefulWidget {
   final String imagePath;
   final int cacheSize;
 
-  const LocalImageLoader(
-      {super.key, required this.imagePath, this.cacheSize = 500});
+  const LocalImageLoader({
+    super.key,
+    required this.imagePath,
+    this.cacheSize = 500,
+  });
+
+  @override
+  State<LocalImageLoader> createState() => _LocalImageLoaderState();
+}
+
+class _LocalImageLoaderState extends State<LocalImageLoader> {
+  Uint8List? _bytes;
+  bool _imageNotFound = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final bytes = await LocalImageCache.instance
+        .getResizedImageBytes(widget.imagePath, widget.cacheSize);
+    if (mounted) {
+      if (bytes != null) {
+        setState(() => _bytes = bytes);
+      } else {
+        setState(() => _imageNotFound = true);
+      }
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
-    return FutureBuilder<Uint8List?>(
-        future:
-            LocalImageCache.instance.getResizedImageBytes(imagePath, cacheSize),
-        builder: (context, snapshot) {
-          if (snapshot.connectionState == ConnectionState.waiting) {
-            return const Center(child: SizedBox());
-          } else if (snapshot.hasError) {
-            return Text('${snapshot.error}');
-          } else if (snapshot.hasData) {
-            return FractionallySizedBox(
-              widthFactor: 1,
-              child: Image.memory(
-                snapshot.data!,
-                fit: BoxFit.cover,
-                cacheWidth: cacheSize,
-              ),
-            );
-          } else {
-            // Image not found
-            return const Center(
-              child: Icon(
-                Icons.image_search_rounded,
-                size: 36,
-              ),
-            );
-          }
-        });
+    if (_bytes != null) {
+      return FractionallySizedBox(
+        widthFactor: 1,
+        child: Image.memory(_bytes!,
+            fit: BoxFit.cover,
+            cacheWidth: widget.cacheSize, errorBuilder: (_, __, ___) {
+          return const Center(
+            child: Icon(
+              Icons.broken_image_rounded,
+              size: 36,
+            ),
+          );
+        }),
+      );
+    } else {
+      if (_imageNotFound) {
+        // Image not found
+        return const Center(
+          child: Icon(
+            Icons.image_search_rounded,
+            size: 36,
+          ),
+        );
+      } else {
+        // Placeholder while image loads
+        return const SizedBox.expand();
+      }
+    }
   }
 }


### PR DESCRIPTION
Keeping the image stateless and spawning a future was causing a visible flicker every time the widget tree rebuild. This fix avoids image flickering.