### PR TITLE
fix: support non-latin languages for word count

### DIFF
--- a/lib/stats_provider.dart
+++ b/lib/stats_provider.dart
@@ -6,6 +6,7 @@ import 'package:daily_you/time_manager.dart';
 import 'package:daily_you/widgets/stat_range_selector.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:word_count/word_count.dart';
 
 enum OrderBy { date, mood }
 
@@ -101,8 +102,7 @@ class StatsProvider with ChangeNotifier {
   void getWordCount() {
     wordCount = 0;
     for (var entry in entries) {
-      final RegExp regex = RegExp(r'\w+');
-      wordCount += regex.allMatches(entry.text).length;
+      wordCount += wordsCount(entry.text);
     }
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1222,6 +1222,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  word_count:
+    dependency: "direct main"
+    description:
+      name: word_count
+      sha256: "98ccd8ef6d614bcf11a7e6d39d43d08193a3a42d360104234018d1dfb86c413d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   xdg_directories:
     dependency: transitive
     description:
@@ -1247,5 +1255,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
+  dart: ">=3.8.1 <4.0.0"
   flutter: ">=3.29.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -57,6 +57,7 @@ dependencies:
   local_auth: ^2.3.0
   crypto: ^3.0.6
   flutter_svg: ^2.2.0
+  word_count: ^1.0.4
 dev_dependencies:
   flutter_lints: ^5.0.0
 


### PR DESCRIPTION
Add support for non-latin languages to the word count statistic.

closes #272 