### PR TITLE
feat: Add multi-day share

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:daily_you/notification_manager.dart';
 import 'package:daily_you/pages/launch_page.dart';
 import 'package:daily_you/providers/entries_provider.dart';
 import 'package:daily_you/providers/entry_images_provider.dart';
+import 'package:daily_you/providers/selection_provider.dart';
 import 'package:daily_you/providers/templates_provider.dart';
 import 'package:daily_you/time_manager.dart';
 import 'package:flutter/material.dart';
@@ -106,6 +107,9 @@ void main() async {
     ),
     ChangeNotifierProvider<ConfigProvider>(
       create: (_) => ConfigProvider.instance,
+    ),
+    ChangeNotifierProvider<SelectionProvider>(
+      create: (_) => SelectionProvider(),
     )
   ], builder: (context, child) => const MainApp()));
 }

--- a/lib/providers/selection_provider.dart
+++ b/lib/providers/selection_provider.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+class SelectionProvider extends ChangeNotifier {
+  final Set<DateTime> _selectedDates = {};
+
+  bool get isSelectionMode => _selectedDates.isNotEmpty;
+  Set<DateTime> get selectedDates => Set.unmodifiable(_selectedDates);
+  int get selectedCount => _selectedDates.length;
+
+  void toggleDate(DateTime date) {
+    DateTime normalized = DateTime(date.year, date.month, date.day);
+    if (_selectedDates.contains(normalized)) {
+      _selectedDates.remove(normalized);
+    } else {
+      _selectedDates.add(normalized);
+    }
+    notifyListeners();
+  }
+
+  bool isSelected(DateTime date) {
+    DateTime normalized = DateTime(date.year, date.month, date.day);
+    return _selectedDates.contains(normalized);
+  }
+
+  void clearSelection() {
+    _selectedDates.clear();
+    notifyListeners();
+  }
+}

--- a/lib/widgets/entry_day_cell.dart
+++ b/lib/widgets/entry_day_cell.dart
@@ -2,6 +2,7 @@ import 'package:daily_you/config_provider.dart';
 import 'package:daily_you/models/image.dart';
 import 'package:daily_you/providers/entries_provider.dart';
 import 'package:daily_you/providers/entry_images_provider.dart';
+import 'package:daily_you/providers/selection_provider.dart';
 import 'package:daily_you/time_manager.dart';
 import 'package:daily_you/widgets/local_image_loader.dart';
 import 'package:flutter/material.dart';
@@ -20,13 +21,82 @@ class EntryDayCell extends StatelessWidget {
   const EntryDayCell(
       {super.key, required this.date, required this.currentMonth});
 
+  Future<void> _handleTap(
+    BuildContext context,
+    Entry? entry,
+    bool isSelectionMode,
+    SelectionProvider selectionProvider,
+    EntriesProvider entriesProvider,
+  ) async {
+    if (isSelectionMode) {
+      // Toggle selection instead of navigating
+      selectionProvider.toggleDate(date);
+    } else {
+      // Existing navigation logic
+      if (entry != null) {
+        await Navigator.of(context).push(MaterialPageRoute(
+          allowSnapshotting: false,
+          builder: (context) => EntryDetailPage(
+            filtered: false,
+            index: entriesProvider.getIndexOfEntry(entry.id!),
+          ),
+        ));
+      } else {
+        await Navigator.of(context).push(MaterialPageRoute(
+          allowSnapshotting: false,
+          builder: (context) => AddEditEntryPage(
+            overrideCreateDate: TimeManager.currentTimeOnDifferentDate(date)
+                .copyWith(isUtc: false),
+          ),
+        ));
+      }
+    }
+  }
+
+  Widget _wrapWithSelection(
+    BuildContext context,
+    Widget cellContent,
+    bool isSelected,
+  ) {
+    if (isSelected) {
+      return Stack(
+        children: [
+          cellContent,
+          // Color overlay
+          Positioned.fill(
+            child: Container(
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.3),
+                borderRadius: BorderRadius.circular(8),
+              ),
+            ),
+          ),
+          // Checkmark icon
+          Positioned(
+            top: 2,
+            right: 2,
+            child: Icon(
+              Icons.check_circle,
+              color: Theme.of(context).colorScheme.primary,
+              size: 20,
+            ),
+          ),
+        ],
+      );
+    }
+    return cellContent;
+  }
+
   @override
   Widget build(BuildContext context) {
     final entriesProvider = Provider.of<EntriesProvider>(context);
     final entryImagesProvider = Provider.of<EntryImagesProvider>(context);
     final configProvider = Provider.of<ConfigProvider>(context);
+    final selectionProvider = Provider.of<SelectionProvider>(context);
 
     Entry? entry = entriesProvider.getEntryForDate(date);
+    bool isSelected = selectionProvider.isSelected(date);
+    bool isSelectionMode = selectionProvider.isSelectionMode;
 
     EntryImage? image;
     if (entry != null) {
@@ -35,97 +105,77 @@ class EntryDayCell extends StatelessWidget {
 
     bool showMood = configProvider.get(ConfigKey.calendarViewMode) == 'mood';
 
+    Widget cellContent;
+
     if (entry != null) {
       if (showMood || image == null) {
         // Show mood
-        return FittedBox(
+        cellContent = FittedBox(
           fit: BoxFit.scaleDown,
-          child: GestureDetector(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Text(
-                  '${date.day}',
-                  style: const TextStyle(fontSize: 16),
-                ),
-                MoodIcon(moodValue: entry.mood)
-              ],
-            ),
-            onTap: () async {
-              await Navigator.of(context).push(MaterialPageRoute(
-                allowSnapshotting: false,
-                builder: (context) => EntryDetailPage(
-                  filtered: false,
-                  index: entriesProvider.getIndexOfEntry(entry.id!),
-                ),
-              ));
-            },
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(
+                '${date.day}',
+                style: const TextStyle(fontSize: 16),
+              ),
+              MoodIcon(moodValue: entry.mood)
+            ],
           ),
         );
       } else {
         // Show image
-        return GestureDetector(
-          child: Container(
+        cellContent = Container(
+          alignment: Alignment.center,
+          child: Stack(
             alignment: Alignment.center,
-            child: Stack(
-              alignment: Alignment.center,
-              children: [
-                SizedBox(
-                  height: 57,
-                  child: Card(
-                      margin: EdgeInsets.all(2),
-                      shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.all(Radius.circular(8))),
-                      clipBehavior: Clip.antiAlias,
-                      child: LocalImageLoader(
-                        imagePath: image.imgPath,
-                        cacheSize: 100,
-                      )),
-                ),
-                Text('${date.day}',
-                    style:
-                        TextStyle(fontSize: 18, color: Colors.white, shadows: [
-                      Shadow(
-                          color: Colors.black.withValues(alpha: 0.8),
-                          blurRadius: 6,
-                          offset: Offset(0, 0)),
-                    ])),
-              ],
-            ),
+            children: [
+              SizedBox(
+                height: 57,
+                child: Card(
+                    margin: EdgeInsets.all(2),
+                    shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.all(Radius.circular(8))),
+                    clipBehavior: Clip.antiAlias,
+                    child: LocalImageLoader(
+                      imagePath: image.imgPath,
+                      cacheSize: 100,
+                    )),
+              ),
+              Text('${date.day}',
+                  style:
+                      TextStyle(fontSize: 18, color: Colors.white, shadows: [
+                    Shadow(
+                        color: Colors.black.withValues(alpha: 0.8),
+                        blurRadius: 6,
+                        offset: Offset(0, 0)),
+                  ])),
+            ],
           ),
-          onTap: () async {
-            await Navigator.of(context).push(MaterialPageRoute(
-              allowSnapshotting: false,
-              builder: (context) => EntryDetailPage(
-                  filtered: false,
-                  index: entriesProvider.getIndexOfEntry(entry.id!)),
-            ));
-          },
         );
       }
     } else {
       // No entry
-      return GestureDetector(
-        behavior: HitTestBehavior.translucent,
-        child: Center(
-          child: Text('${date.day}',
-              style: isSameDay(date, DateTime.now())
-                  ? TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.bold,
-                      color: Theme.of(context).colorScheme.primary)
-                  : TextStyle(fontSize: 16)),
-        ),
-        onTap: () async {
-          await Navigator.of(context).push(MaterialPageRoute(
-            allowSnapshotting: false,
-            builder: (context) => AddEditEntryPage(
-              overrideCreateDate: TimeManager.currentTimeOnDifferentDate(date)
-                  .copyWith(isUtc: false),
-            ),
-          ));
-        },
+      cellContent = Center(
+        child: Text('${date.day}',
+            style: isSameDay(date, DateTime.now())
+                ? TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                    color: Theme.of(context).colorScheme.primary)
+                : TextStyle(fontSize: 16)),
       );
     }
+
+    // Wrap with selection overlay if selected
+    cellContent = _wrapWithSelection(context, cellContent, isSelected);
+
+    return GestureDetector(
+      behavior: HitTestBehavior.translucent,
+      onTap: () =>
+          _handleTap(context, entry, isSelectionMode, selectionProvider, entriesProvider),
+      onLongPress: () => selectionProvider.toggleDate(date),
+      child: cellContent,
+    );
   }
 }


### PR DESCRIPTION
### Context
Currently there is an ability to share a single day entry. I was looking to share multiple days.

For my use case, I only needed to share text, but if there's a need, I'd be happy to update the code to share images too. Maybe with an option presented whether to share with images or text only. Not sure what's the ideal UX here.