### PR TITLE
fix: open database after syncing

### DIFF
--- a/lib/database/app_database.dart
+++ b/lib/database/app_database.dart
@@ -25,16 +25,18 @@ class AppDatabase {
 
   Future<bool> init({bool forceWithoutSync = false}) async {
     _internalPath = await getInternalPath();
-    await AppDatabase.instance.open();
+    bool success = true;
 
     if (usingExternalLocation() && !forceWithoutSync) {
       if (await hasExternalLocationPermission()) {
         await _syncWithExternalDatabase();
       } else {
-        return false;
+        success = false;
       }
     }
-    return true;
+
+    await AppDatabase.instance.open();
+    return success;
   }
 
   Future<void> open() async {


### PR DESCRIPTION
Open the database after the initial sync. This addresses a recent regression where the sync logic would run and pull in external changes; however, since the local database was already opened, the new changes would not be adopted.

closes #297