### PR TITLE
fix: reduce build memory footprint

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,3 @@
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx2g
 android.useAndroidX=true
 android.enableJetifier=false


### PR DESCRIPTION
Jetifier is no longer required on modern flutter version and  can be disabled to reduce the memory footprint during builds. As a precaution, the build memory has also been slightly increased for more headroom.

closes #310 