### PR TITLE
fix: avoid duplicate text scaling

### DIFF
--- a/lib/pages/entry_detail_page.dart
+++ b/lib/pages/entry_detail_page.dart
@@ -7,6 +7,7 @@ import 'package:daily_you/models/image.dart';
 import 'package:daily_you/providers/entries_provider.dart';
 import 'package:daily_you/providers/entry_images_provider.dart';
 import 'package:daily_you/time_manager.dart';
+import 'package:daily_you/widgets/scaled_markdown.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:daily_you/l10n/generated/app_localizations.dart';
@@ -249,10 +250,7 @@ class EntryDetails extends StatelessWidget {
                   child: Padding(
                       padding: const EdgeInsets.only(
                           left: 8, top: 4, bottom: 4, right: 8),
-                      child: MarkdownBlock(
-                        config: theme.brightness == Brightness.light
-                            ? MarkdownConfig.defaultConfig
-                            : MarkdownConfig.darkConfig,
+                      child: ScaledMarkdown(
                         data: entry.text,
                       ))),
             Padding(

--- a/lib/widgets/entry_card_widget.dart
+++ b/lib/widgets/entry_card_widget.dart
@@ -1,6 +1,7 @@
 import 'package:daily_you/l10n/generated/app_localizations.dart';
 import 'package:daily_you/models/image.dart';
 import 'package:daily_you/time_manager.dart';
+import 'package:daily_you/widgets/scaled_markdown.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:daily_you/models/entry.dart';
@@ -52,12 +53,7 @@ class EntryCardWidget extends StatelessWidget {
                                   IgnorePointer(
                                       child: SizedBox(
                                     width: double.maxFinite,
-                                    child: MarkdownBlock(
-                                        config:
-                                            theme.brightness == Brightness.light
-                                                ? MarkdownConfig.defaultConfig
-                                                : MarkdownConfig.darkConfig,
-                                        data: entry.text),
+                                    child: ScaledMarkdown(data: entry.text),
                                   ))
                                 ]),
                               )

--- a/lib/widgets/large_entry_card_widget.dart
+++ b/lib/widgets/large_entry_card_widget.dart
@@ -1,5 +1,6 @@
 import 'package:daily_you/models/image.dart';
 import 'package:daily_you/time_manager.dart';
+import 'package:daily_you/widgets/scaled_markdown.dart';
 import 'package:flutter/material.dart';
 import 'package:daily_you/l10n/generated/app_localizations.dart';
 import 'package:intl/intl.dart';
@@ -94,11 +95,7 @@ class LargeEntryCardWidget extends StatelessWidget {
                 child: Wrap(children: [
                   IgnorePointer(
                       child: (entry.text.isNotEmpty)
-                          ? MarkdownBlock(
-                              config: theme.brightness == Brightness.light
-                                  ? MarkdownConfig.defaultConfig
-                                  : MarkdownConfig.darkConfig,
-                              data: entry.text)
+                          ? ScaledMarkdown(data: entry.text)
                           : Text(
                               AppLocalizations.of(context)!.writeSomethingHint,
                               style: TextStyle(

--- a/lib/widgets/scaled_markdown.dart
+++ b/lib/widgets/scaled_markdown.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:markdown_widget/markdown_widget.dart';
+
+// Fixes duplicate scaling issues with markdown_widget
+// See: https://github.com/asjqkkkk/markdown_widget/issues/208
+class ScaledMarkdown extends StatelessWidget {
+  final String data;
+  const ScaledMarkdown({super.key, required this.data});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return MarkdownBlock(
+      config: theme.brightness == Brightness.light
+          ? MarkdownConfig.defaultConfig
+          : MarkdownConfig.darkConfig,
+      generator: MarkdownGenerator(richTextBuilder: (span) {
+        return Builder(builder: (context) {
+          final shouldIgnoreTextScaler =
+              context.getInheritedWidgetOfExactType<_WithTextScalar>() != null;
+          final child = Text.rich(span);
+          return shouldIgnoreTextScaler
+              ? MediaQuery.withNoTextScaling(child: child)
+              : _WithTextScalar(child: child);
+        });
+      }),
+      data: data,
+    );
+  }
+}
+
+class _WithTextScalar extends InheritedWidget {
+  const _WithTextScalar({required super.child});
+
+  @override
+  bool updateShouldNotify(covariant _WithTextScalar oldWidget) {
+    return false;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
       ref: release
   device_info_plus: ^11.2.0
   fl_chart: ^0.66.2
-  markdown_widget: ^2.3.2+3
+  markdown_widget: ^2.3.2+8
 
   intl: ^0.20.0
   share_plus: ^10.1.3


### PR DESCRIPTION
Prevent nested Markdown elements from being scaled multiple times when the user has a non-default system text size.

closes #304
closes #317 