### PR TITLE
fix: use dynamic color scheme when available

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,7 @@ import 'package:daily_you/providers/entries_provider.dart';
 import 'package:daily_you/providers/entry_images_provider.dart';
 import 'package:daily_you/providers/templates_provider.dart';
 import 'package:daily_you/time_manager.dart';
+import 'package:dynamic_color/dynamic_color.dart';
 import 'package:flutter/material.dart';
 import 'package:daily_you/l10n/generated/app_localizations.dart';
 import 'package:daily_you/layouts/mobile_scaffold.dart';
@@ -177,77 +178,95 @@ class _MainAppState extends State<MainApp> {
   Widget build(BuildContext context) {
     final themeModeProvider = Provider.of<ThemeModeProvider>(context);
     final configProvider = Provider.of<ConfigProvider>(context);
+    return DynamicColorBuilder(
+        builder: (ColorScheme? lightDynamic, ColorScheme? darkDynamic) {
+      ThemeData lightTheme;
+      ThemeData darkTheme;
 
-    return StatsFl(
-      isEnabled: false,
-      child: GestureDetector(
-          onTap: () {
-            FocusManager.instance.primaryFocus?.unfocus();
-          },
-          child: MaterialApp(
-              onGenerateTitle: (context) =>
-                  AppLocalizations.of(context)!.appTitle,
-              title: 'Daily You',
-              themeMode: themeModeProvider.themeMode,
-              debugShowCheckedModeBanner: false,
-              localizationsDelegates: <LocalizationsDelegate<dynamic>>[
-                AppLocalizations.delegate,
-                CustomMaterialLocalizationsDelegate(),
-                CustomCupertinoLocalizationsDelegate(),
-                CustomWidgetsLocalizationsDelegate(),
-              ],
-              locale: configProvider.getOverrideLanguage(),
-              supportedLocales: [
-                Locale("en"),
-                ...AppLocalizations.supportedLocales
-                    .where((locale) => locale.languageCode != "en")
-              ],
-              localeResolutionCallback: (locale, supportedLocales) {
-                return configProvider.getOverrideLanguage();
-              },
-              theme: ThemeData(
-                useMaterial3: true,
-                colorScheme: ColorScheme.fromSeed(
-                    seedColor: themeModeProvider.accentColor,
-                    brightness: Brightness.light),
-              ),
-              darkTheme:
-                  (ConfigProvider.instance.get(ConfigKey.theme) == 'amoled')
-                      ? ThemeData(
-                          useMaterial3: true,
-                          colorScheme: ColorScheme.fromSeed(
-                            seedColor: themeModeProvider.accentColor,
-                            brightness: Brightness.dark,
-                            surfaceContainerLowest: Colors.black,
-                            surfaceContainerLow: Colors.black,
-                            surfaceContainerHighest: Colors.black,
-                            surfaceContainerHigh: Colors.black,
-                            surfaceBright: Colors.black,
-                            surfaceDim: Colors.black,
-                            surface: Colors.black,
-                            surfaceContainer: Colors.black,
-                            onSurface: Colors.white,
-                            surfaceTint: Colors.black,
-                            primaryContainer: Colors.black,
-                            secondaryContainer: Colors.black,
-                            tertiaryContainer: Colors.black,
-                            inverseSurface: Colors.black,
-                            inversePrimary: Colors.black,
-                            scrim: Colors.black,
-                          ),
-                          scaffoldBackgroundColor: Colors.black)
-                      : ThemeData(
-                          useMaterial3: true,
-                          colorScheme: ColorScheme.fromSeed(
-                              seedColor: themeModeProvider.accentColor,
-                              brightness: Brightness.dark),
-                        ),
-              home: LaunchPage(
-                  nextPage: ResponsiveLayout(
-                mobileScaffold: MobileScaffold(),
-                tabletScaffold: MobileScaffold(),
-                desktopScaffold: MobileScaffold(),
-              )))),
-    );
+      if (themeModeProvider.usingSystemColor && lightDynamic != null) {
+        lightTheme = ThemeData(colorScheme: lightDynamic.harmonized());
+      } else {
+        lightTheme = ThemeData(
+            useMaterial3: true,
+            colorScheme: ColorScheme.fromSeed(
+                seedColor: themeModeProvider.accentColor,
+                brightness: Brightness.light));
+      }
+
+      if (themeModeProvider.usingSystemColor && darkDynamic != null) {
+        darkTheme = ThemeData(colorScheme: darkDynamic.harmonized());
+      } else {
+        darkTheme = ThemeData(
+          useMaterial3: true,
+          colorScheme: ColorScheme.fromSeed(
+              seedColor: themeModeProvider.accentColor,
+              brightness: Brightness.dark),
+        );
+      }
+
+      // amoled override
+      if (ConfigProvider.instance.get(ConfigKey.theme) == 'amoled') {
+        darkTheme = ThemeData(
+            useMaterial3: true,
+            colorScheme: ColorScheme.fromSeed(
+              seedColor: themeModeProvider.accentColor,
+              brightness: Brightness.dark,
+              surfaceContainerLowest: Colors.black,
+              surfaceContainerLow: Colors.black,
+              surfaceContainerHighest: Colors.black,
+              surfaceContainerHigh: Colors.black,
+              surfaceBright: Colors.black,
+              surfaceDim: Colors.black,
+              surface: Colors.black,
+              surfaceContainer: Colors.black,
+              onSurface: Colors.white,
+              surfaceTint: Colors.black,
+              primaryContainer: Colors.black,
+              secondaryContainer: Colors.black,
+              tertiaryContainer: Colors.black,
+              inverseSurface: Colors.black,
+              inversePrimary: Colors.black,
+              scrim: Colors.black,
+            ),
+            scaffoldBackgroundColor: Colors.black);
+      }
+
+      return StatsFl(
+        isEnabled: false,
+        child: GestureDetector(
+            onTap: () {
+              FocusManager.instance.primaryFocus?.unfocus();
+            },
+            child: MaterialApp(
+                onGenerateTitle: (context) =>
+                    AppLocalizations.of(context)!.appTitle,
+                title: 'Daily You',
+                themeMode: themeModeProvider.themeMode,
+                debugShowCheckedModeBanner: false,
+                localizationsDelegates: <LocalizationsDelegate<dynamic>>[
+                  AppLocalizations.delegate,
+                  CustomMaterialLocalizationsDelegate(),
+                  CustomCupertinoLocalizationsDelegate(),
+                  CustomWidgetsLocalizationsDelegate(),
+                ],
+                locale: configProvider.getOverrideLanguage(),
+                supportedLocales: [
+                  Locale("en"),
+                  ...AppLocalizations.supportedLocales
+                      .where((locale) => locale.languageCode != "en")
+                ],
+                localeResolutionCallback: (locale, supportedLocales) {
+                  return configProvider.getOverrideLanguage();
+                },
+                theme: lightTheme,
+                darkTheme: darkTheme,
+                home: LaunchPage(
+                    nextPage: ResponsiveLayout(
+                  mobileScaffold: MobileScaffold(),
+                  tabletScaffold: MobileScaffold(),
+                  desktopScaffold: MobileScaffold(),
+                )))),
+      );
+    });
   }
 }

--- a/lib/theme_mode_provider.dart
+++ b/lib/theme_mode_provider.dart
@@ -10,6 +10,8 @@ class ThemeModeProvider with ChangeNotifier {
 
   Color _accentColor = const Color(0xff62A0EA);
   Color get accentColor => _accentColor;
+  bool get usingSystemColor =>
+      ConfigProvider.instance.get(ConfigKey.followSystemColor);
 
   set themeMode(ThemeMode value) {
     _themeMode = value;

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,12 +6,16 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <dynamic_color/dynamic_color_plugin.h>
 #include <file_selector_linux/file_selector_plugin.h>
 #include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <system_theme/system_theme_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) dynamic_color_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "DynamicColorPlugin");
+  dynamic_color_plugin_register_with_registrar(dynamic_color_registrar);
   g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
   file_selector_plugin_register_with_registrar(file_selector_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  dynamic_color
   file_selector_linux
   sqlite3_flutter_libs
   system_theme

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,6 +7,7 @@ import Foundation
 
 import app_settings
 import device_info_plus
+import dynamic_color
 import file_picker
 import file_selector_macos
 import flutter_image_compress_macos
@@ -24,6 +25,7 @@ import url_launcher_macos
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppSettingsPlugin.register(with: registry.registrar(forPlugin: "AppSettingsPlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
+  DynamicColorPlugin.register(with: registry.registrar(forPlugin: "DynamicColorPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FlutterImageCompressMacosPlugin.register(with: registry.registrar(forPlugin: "FlutterImageCompressMacosPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -41,6 +41,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.13.0"
+  boolean_selector:
+    dependency: transitive
+    description:
+      name: boolean_selector
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
   characters:
     dependency: transitive
     description:
@@ -121,6 +129,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.3"
+  dynamic_color:
+    dependency: "direct main"
+    description:
+      name: dynamic_color
+      sha256: "43a5a6679649a7731ab860334a5812f2067c2d9ce6452cf069c5e0c25336c17c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.8.1"
   easy_debounce:
     dependency: "direct main"
     description:
@@ -153,6 +169,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.6"
+  fake_async:
+    dependency: transitive
+    description:
+      name: fake_async
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.3"
   ffi:
     dependency: transitive
     description:
@@ -371,6 +395,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  flutter_test:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -520,6 +549,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.2"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.0.2"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.10"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -584,6 +637,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2+8"
+  matcher:
+    dependency: transitive
+    description:
+      name: matcher
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1054,6 +1115,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  stream_channel:
+    dependency: transitive
+    description:
+      name: stream_channel
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
@@ -1102,6 +1171,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.2"
+  test_api:
+    dependency: transitive
+    description:
+      name: test_api
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.7"
   time_range_picker:
     dependency: "direct main"
     description:
@@ -1246,6 +1323,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.4.0+2"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
+      url: "https://pub.dev"
+    source: hosted
+    version: "15.0.2"
   web:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,6 +62,7 @@ dependencies:
   csv: ^6.0.0
   quick_actions: ^1.1.0
   flutter_displaymode: ^0.7.0
+  dynamic_color: ^1.8.1
 dev_dependencies:
   flutter_lints: ^5.0.0
 

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,7 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <dynamic_color/dynamic_color_plugin_c_api.h>
 #include <file_selector_windows/file_selector_windows.h>
 #include <local_auth_windows/local_auth_plugin.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
@@ -15,6 +16,8 @@
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  DynamicColorPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("DynamicColorPluginCApi"));
   FileSelectorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
   LocalAuthPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  dynamic_color
   file_selector_windows
   local_auth_windows
   permission_handler_windows


### PR DESCRIPTION
Use the system's dynamic color scheme when available. Fall back to a generated color scheme. Generated color schemes inject chroma and do not support monochrome. With this change system monochrome themes will be accepted. The AMOLED theme will still use a generated color scheme and does not currently support grey scale.

closes #344 