### PR TITLE
feat: add share image to diary entry #340

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -54,6 +54,18 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <!-- Share single image -->
+            <intent-filter>
+                <action android:name="android.intent.action.SEND"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:mimeType="image/*"/>
+            </intent-filter>
+            <!-- Share multiple images -->
+            <intent-filter>
+                <action android:name="android.intent.action.SEND_MULTIPLE"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:mimeType="image/*"/>
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/android/app/src/main/kotlin/com/example/daily_you/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/daily_you/MainActivity.kt
@@ -1,17 +1,97 @@
 package com.demizo.daily_you
 
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
 import io.flutter.embedding.android.FlutterFragmentActivity
 import io.flutter.embedding.engine.FlutterEngine
 import SafTransferPlugin
-import android.content.Intent;
+import io.flutter.plugin.common.MethodChannel
 
-class MainActivity: FlutterFragmentActivity() {
-  override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-    super.onActivityResult(requestCode, resultCode, data)
-  }
+class MainActivity : FlutterFragmentActivity() {
+    private val CHANNEL = "com.demizo.daily_you/share"
+    private var pendingUris: List<String>? = null
+    private var methodChannel: MethodChannel? = null
 
-  override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
-    super.configureFlutterEngine(flutterEngine)
-    flutterEngine.plugins.add(SafTransferPlugin())
-  }
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        flutterEngine.plugins.add(SafTransferPlugin())
+        methodChannel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL)
+        methodChannel!!.setMethodCallHandler { call, result ->
+            when (call.method) {
+                "getInitialSharedFiles" -> {
+                    result.success(pendingUris)
+                    pendingUris = null
+                }
+                "readFileBytes" -> {
+                    val uriString = call.argument<String>("uri")
+                    Thread {
+                        try {
+                            val uri = Uri.parse(uriString)
+                            val bytes = contentResolver.openInputStream(uri)?.readBytes()
+                            result.success(bytes)
+                        } catch (e: Exception) {
+                            result.error("READ_ERROR", e.message, null)
+                        }
+                    }.start()
+                }
+                else -> result.notImplemented()
+            }
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        handleIntent(intent)
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        handleIntent(intent)
+        // Deliver to Flutter immediately if engine is already running
+        val uris = pendingUris
+        if (uris != null) {
+            pendingUris = null
+            methodChannel?.invokeMethod("onSharedFiles", uris)
+        }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+    }
+
+    private fun handleIntent(intent: Intent) {
+        try {
+            when (intent.action) {
+                Intent.ACTION_SEND -> {
+                    if (intent.type?.startsWith("image/") == true) {
+                        @Suppress("DEPRECATION")
+                        val uri = intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM)
+                        if (uri != null) {
+                            // Workaround: some ROMs don't propagate URI read permission reliably
+                            grantUriPermission(packageName, uri,
+                                Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                            pendingUris = listOf(uri.toString())
+                        }
+                    }
+                }
+                Intent.ACTION_SEND_MULTIPLE -> {
+                    if (intent.type?.startsWith("image/") == true) {
+                        @Suppress("DEPRECATION")
+                        val uris = intent.getParcelableArrayListExtra<Uri>(Intent.EXTRA_STREAM)
+                        if (!uris.isNullOrEmpty()) {
+                            uris.forEach { uri ->
+                                try {
+                                    grantUriPermission(packageName, uri,
+                                        Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                                } catch (_: Exception) {}
+                            }
+                            pendingUris = uris.map { it.toString() }
+                        }
+                    }
+                }
+            }
+        } catch (_: Exception) {}
+    }
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -316,5 +316,15 @@
   "settingsConsiderSupporting": "consider supporting",
   "@settingsConsiderSupporting": {},
   "tagMoodTitle": "Mood",
-  "@tagMoodTitle": {}
+  "@tagMoodTitle": {},
+  "shareToEntryTitle": "Add to Diary",
+  "@shareToEntryTitle": {},
+  "addToToday": "Today",
+  "@addToToday": {},
+  "selectDate": "Select Date",
+  "@selectDate": {},
+  "addToEntry": "Add to Diary",
+  "@addToEntry": {},
+  "shareErrorProcessing": "Could not process the shared image(s).",
+  "@shareErrorProcessing": {}
 }

--- a/lib/launch_intent.dart
+++ b/lib/launch_intent.dart
@@ -3,6 +3,8 @@ sealed class LaunchIntent {
 
   const factory LaunchIntent.logToday() = LogTodayIntent;
   const factory LaunchIntent.takePhoto() = TakePhotoIntent;
+  const factory LaunchIntent.shareFiles(List<String> filePaths) =
+      ShareFilesIntent;
 }
 
 class TakePhotoIntent extends LaunchIntent {
@@ -11,4 +13,11 @@ class TakePhotoIntent extends LaunchIntent {
 
 class LogTodayIntent extends LaunchIntent {
   const LogTodayIntent();
+}
+
+/// Carries local file paths (as resolved by the `receive_sharing_intent`
+/// plugin from content:// URIs) for images the user shared to Daily You.
+class ShareFilesIntent extends LaunchIntent {
+  final List<String> filePaths;
+  const ShareFilesIntent(this.filePaths);
 }

--- a/lib/layouts/mobile_scaffold.dart
+++ b/lib/layouts/mobile_scaffold.dart
@@ -1,8 +1,11 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:daily_you/config_provider.dart';
 import 'package:daily_you/layouts/fast_page_view_scroll_physics.dart';
 import 'package:daily_you/pages/settings/notification_settings.dart';
+import 'package:daily_you/pages/share_to_entry_page.dart';
+import 'package:daily_you/services/share_intent_service.dart';
 import 'package:easy_debounce/easy_debounce.dart';
 import 'package:flutter/material.dart';
 import 'package:daily_you/l10n/generated/app_localizations.dart';
@@ -24,6 +27,7 @@ class _MobileScaffoldState extends State<MobileScaffold> {
   int currentIndex = 0;
   late final PageController _pageController;
   final List<bool> _isScrolled = [false, false, false];
+  StreamSubscription<List<String>>? _shareSubscription;
 
   final List<Widget> pages = [
     const HomePage(),
@@ -35,12 +39,29 @@ class _MobileScaffoldState extends State<MobileScaffold> {
   void initState() {
     super.initState();
     _pageController = PageController(initialPage: currentIndex);
+    // Warm-start share: subscribe to raw file paths emitted by the plugin
+    // while the app is running.
+    if (Platform.isAndroid || Platform.isIOS) {
+      _shareSubscription = ShareIntentService.instance.sharingFilesStream
+          .listen(_onSharePaths);
+    }
   }
 
   @override
   void dispose() {
+    _shareSubscription?.cancel();
     _pageController.dispose();
     super.dispose();
+  }
+
+  Future<void> _onSharePaths(List<String> paths) async {
+    if (!mounted) return;
+    await Navigator.of(context).push(
+      MaterialPageRoute(
+        allowSnapshotting: false,
+        builder: (_) => ShareToEntryPage(sharedUris: paths),
+      ),
+    );
   }
 
   void _showNotificationOnboardingPopup() {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'package:daily_you/pages/launch_page.dart';
 import 'package:daily_you/providers/entries_provider.dart';
 import 'package:daily_you/providers/entry_images_provider.dart';
 import 'package:daily_you/providers/templates_provider.dart';
+import 'package:daily_you/services/share_intent_service.dart';
 import 'package:daily_you/time_manager.dart';
 import 'package:dynamic_color/dynamic_color.dart';
 import 'package:flutter/material.dart';
@@ -92,6 +93,11 @@ void main() async {
     await NotificationManager.instance.init();
 
     await AndroidAlarmManager.initialize();
+
+    // Register the warm-start share listener early so no shares are missed
+    // while the app is loading. Cold-start image processing is deferred to
+    // LaunchPage (after the database is ready).
+    ShareIntentService.instance.init();
   }
 
   runApp(MultiProvider(providers: [

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -7,6 +7,7 @@ import 'package:daily_you/launch_intent.dart';
 import 'package:daily_you/models/flashback.dart';
 import 'package:daily_you/models/image.dart';
 import 'package:daily_you/notification_manager.dart';
+import 'package:daily_you/pages/share_to_entry_page.dart';
 import 'package:daily_you/providers/entries_provider.dart';
 import 'package:daily_you/providers/entry_images_provider.dart';
 import 'package:daily_you/time_manager.dart';
@@ -41,8 +42,10 @@ class _HomePageState extends State<HomePage>
   @override
   void initState() {
     super.initState();
-    _checkForLaunchIntent();
-    _checkForNotificationLaunch();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _checkForLaunchIntent();
+      _checkForNotificationLaunch();
+    });
   }
 
   @override
@@ -63,15 +66,28 @@ class _HomePageState extends State<HomePage>
 
   Future _checkForLaunchIntent() async {
     final intent = DeviceInfoService().launchIntent;
-    if (intent != null) {
-      Entry? todayEntry = EntriesProvider.instance.getEntryForToday();
-      List<EntryImage> todayImages = todayEntry != null
-          ? EntryImagesProvider.instance.getForEntry(todayEntry)
-          : [];
-      bool openCamera = (intent is TakePhotoIntent) ? true : false;
-      DeviceInfoService().launchIntent = null;
-      await addOrEditTodayEntry(todayEntry, todayImages, openCamera);
+    if (intent == null) return;
+
+    DeviceInfoService().launchIntent = null;
+
+    if (intent is ShareFilesIntent) {
+      // Cold-start share: show the share-to-entry UI for date selection.
+      await Navigator.of(context).push(
+        MaterialPageRoute(
+          allowSnapshotting: false,
+          builder: (_) => ShareToEntryPage(sharedUris: intent.filePaths),
+        ),
+      );
+      return;
     }
+
+    // LogTodayIntent and TakePhotoIntent.
+    Entry? todayEntry = EntriesProvider.instance.getEntryForToday();
+    List<EntryImage> todayImages = todayEntry != null
+        ? EntryImagesProvider.instance.getForEntry(todayEntry)
+        : [];
+    bool openCamera = (intent is TakePhotoIntent) ? true : false;
+    await addOrEditTodayEntry(todayEntry, todayImages, openCamera);
   }
 
   Future _checkForNotificationLaunch() async {

--- a/lib/pages/launch_page.dart
+++ b/lib/pages/launch_page.dart
@@ -1,8 +1,11 @@
+import 'dart:io';
+
 import 'package:daily_you/config_provider.dart';
 import 'package:daily_you/database/app_database.dart';
 import 'package:daily_you/database/image_storage.dart';
 import 'package:daily_you/device_info_service.dart';
 import 'package:daily_you/launch_intent.dart';
+import 'package:daily_you/services/share_intent_service.dart';
 import 'package:daily_you/widgets/auth_popup.dart';
 import 'package:flutter/material.dart';
 import 'package:daily_you/l10n/generated/app_localizations.dart';
@@ -92,6 +95,18 @@ class _LaunchPageState extends State<LaunchPage> {
     }
     //Initialize Database
     if (await AppDatabase.instance.init()) {
+      // Cold-start share: await before navigating so the intent isn't lost
+      // when this page is replaced. Paths are stored in DeviceInfoService and
+      // consumed by MobileScaffold.initState → ShareToEntryPage.
+      if (Platform.isAndroid || Platform.isIOS) {
+        final coldStartPaths =
+            await ShareIntentService.instance.getInitialSharedFiles();
+        if (coldStartPaths != null && coldStartPaths.isNotEmpty) {
+          DeviceInfoService().launchIntent =
+              LaunchIntent.shareFiles(coldStartPaths);
+        }
+      }
+
       if (ImageStorage.instance.usingExternalLocation()) {
         if (await ImageStorage.instance.hasExternalLocationPermission()) {
           await _nextPage();

--- a/lib/pages/share_to_entry_page.dart
+++ b/lib/pages/share_to_entry_page.dart
@@ -1,0 +1,289 @@
+import 'package:daily_you/models/entry.dart';
+import 'package:daily_you/pages/edit_entry_page.dart';
+import 'package:daily_you/providers/entries_provider.dart';
+import 'package:daily_you/providers/entry_images_provider.dart';
+import 'package:daily_you/services/share_intent_service.dart';
+import 'package:daily_you/time_manager.dart';
+import 'package:daily_you/widgets/share_image_preview.dart';
+import 'package:flutter/material.dart';
+import 'package:daily_you/l10n/generated/app_localizations.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+
+/// The entry-point page shown when the user shares images into Daily You.
+///
+/// Displays:
+///  - a preview of the shared image(s)
+///  - a date selection area (quick "Today" chip + calendar picker)
+///  - Cancel / Add to Diary action buttons
+///
+/// On confirmation it compresses the images via [ShareIntentService] and
+/// pushes [AddEditEntryPage] with the pre-loaded images.
+class ShareToEntryPage extends StatefulWidget {
+  /// Raw URI strings (content:// or file paths) for the incoming images.
+  final List<String> sharedUris;
+
+  const ShareToEntryPage({super.key, required this.sharedUris});
+
+  @override
+  State<ShareToEntryPage> createState() => _ShareToEntryPageState();
+}
+
+class _ShareToEntryPageState extends State<ShareToEntryPage> {
+  late DateTime _selectedDate;
+  bool _processing = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedDate = DateTime.now();
+  }
+
+  bool get _isToday => TimeManager.isToday(_selectedDate);
+
+  Future<void> _pickDate() async {
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: _selectedDate,
+      firstDate: DateTime.utc(2000),
+      lastDate: DateTime.now(),
+      initialDatePickerMode: DatePickerMode.day,
+    );
+    if (picked != null && mounted) {
+      setState(() {
+        _selectedDate = _selectedDate.copyWith(
+          year: picked.year,
+          month: picked.month,
+          day: picked.day,
+        );
+      });
+    }
+  }
+
+  Future<void> _addToEntry() async {
+    if (_processing) return;
+    setState(() => _processing = true);
+
+    final entriesProvider =
+        Provider.of<EntriesProvider>(context, listen: false);
+    final entryImagesProvider =
+        Provider.of<EntryImagesProvider>(context, listen: false);
+
+    // Resolved before the try block so the catch can roll back if needed.
+    final existingEntry = entriesProvider.getEntryForDate(_selectedDate);
+
+    // Promoted outside try so catch can reference it for rollback.
+    Entry? targetEntry;
+
+    try {
+      final overrideDate = TimeManager.isToday(_selectedDate)
+          ? DateTime.now()
+          : TimeManager.currentTimeOnDifferentDate(_selectedDate);
+
+      // Resolve (or create) the target entry so we have a real database id
+      // before we store the images. This prevents entryId=-1 breaking the
+      // image → entry association.
+      targetEntry = existingEntry ??
+          await entriesProvider.createNewEntry(overrideDate);
+      final entryId = targetEntry!.id!;
+
+      final savedImages = await ShareIntentService.instance
+          .saveSharedImages(widget.sharedUris, entryId);
+
+      if (!mounted) return;
+
+      // If no images could be processed, inform the user and stay on the page.
+      if (savedImages.isEmpty) {
+        // Roll back the newly created entry if we made one and it's empty.
+        if (existingEntry == null) {
+          await entriesProvider.remove(targetEntry!);
+        }
+        setState(() => _processing = false);
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(AppLocalizations.of(context)!.shareErrorProcessing),
+          ),
+        );
+        return;
+      }
+
+      // Persist the shared images via the provider so they are in the DB.
+      for (final img in savedImages) {
+        await entryImagesProvider.add(img);
+      }
+
+      if (!mounted) return;
+
+      // Reload all images for the entry (existing + newly added) for the edit page.
+      final allImages = entryImagesProvider.getForEntry(targetEntry!);
+
+      await Navigator.of(context).pushReplacement(
+        MaterialPageRoute(
+          allowSnapshotting: false,
+          builder: (_) => AddEditEntryPage(
+            entry: targetEntry,
+            overrideCreateDate: overrideDate,
+            images: allImages,
+          ),
+        ),
+      );
+    } catch (_) {
+      // Roll back a newly created entry so no empty record is left in the DB.
+      // Only attempt rollback if targetEntry was assigned (i.e. createNewEntry
+      // succeeded before the subsequent failure).
+      if (existingEntry == null && targetEntry != null) {
+        try {
+          await entriesProvider.remove(targetEntry!);
+        } catch (_) {}
+      }
+      if (mounted) {
+        setState(() => _processing = false);
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              AppLocalizations.of(context)!.shareErrorProcessing,
+            ),
+          ),
+        );
+      }
+    }
+  }
+
+  void _cancel() {
+    Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context)!;
+    final locale = TimeManager.currentLocale(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(l10n.shareToEntryTitle),
+        leading: BackButton(onPressed: _cancel),
+      ),
+      body: SafeArea(
+        child: Column(
+          children: [
+            // ── Image preview ──────────────────────────────────────────────
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 12),
+              child: ShareImagePreview(paths: widget.sharedUris),
+            ),
+
+            const Divider(height: 1),
+
+            // ── Date selection ────────────────────────────────────────────
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                    horizontal: 24, vertical: 16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Text(
+                      l10n.selectDate,
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        color: theme.colorScheme.onSurface,
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+
+                    // Today quick-select chip
+                    Wrap(
+                      spacing: 8,
+                      children: [
+                        FilterChip(
+                          selected: _isToday,
+                          label: Text(l10n.addToToday),
+                          onSelected: (_) {
+                            setState(() => _selectedDate = DateTime.now());
+                          },
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 20),
+
+                    // Calendar picker trigger + selected date display
+                    InkWell(
+                      borderRadius: BorderRadius.circular(12),
+                      onTap: _pickDate,
+                      child: Ink(
+                        decoration: BoxDecoration(
+                          color: theme.colorScheme.surfaceContainerHighest,
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 16, vertical: 14),
+                          child: Row(
+                            children: [
+                              Icon(
+                                Icons.calendar_month_rounded,
+                                color: theme.colorScheme.primary,
+                              ),
+                              const SizedBox(width: 12),
+                              Expanded(
+                                child: Text(
+                                  DateFormat.yMMMEd(locale)
+                                      .format(_selectedDate),
+                                  style: theme.textTheme.bodyLarge?.copyWith(
+                                    color: theme.colorScheme.onSurface,
+                                  ),
+                                ),
+                              ),
+                              Icon(
+                                Icons.chevron_right_rounded,
+                                color: theme.colorScheme.onSurfaceVariant,
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+
+            // ── Action buttons ────────────────────────────────────────────
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: OutlinedButton(
+                      onPressed: _processing ? null : _cancel,
+                      child: Text(
+                          MaterialLocalizations.of(context).cancelButtonLabel),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    flex: 2,
+                    child: FilledButton.icon(
+                      onPressed: _processing ? null : _addToEntry,
+                      icon: _processing
+                          ? SizedBox(
+                              width: 18,
+                              height: 18,
+                              child: CircularProgressIndicator(
+                                strokeWidth: 2,
+                                color: theme.colorScheme.onPrimary,
+                              ),
+                            )
+                          : const Icon(Icons.book_rounded),
+                      label: Text(l10n.addToEntry),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/share_intent_service.dart
+++ b/lib/services/share_intent_service.dart
@@ -1,0 +1,197 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:daily_you/config_provider.dart';
+import 'package:daily_you/database/image_storage.dart';
+import 'package:daily_you/models/image.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_image_compress/flutter_image_compress.dart';
+import 'package:path/path.dart' show extension;
+
+/// Handles incoming shared images from Android via a custom MethodChannel.
+///
+/// Integration points:
+///   - [init] is called once in `main()` (inside the Android block) to
+///     register the warm-start stream listener before the app renders.
+///   - [getInitialSharedFiles] is called in `LaunchPage._checkDatabaseConnection`
+///     after `AppDatabase.instance.init()` succeeds. The result is stored as a
+///     `ShareFilesIntent` in `DeviceInfoService` and consumed by
+///     `HomePage._checkForLaunchIntent` → `ShareToEntryPage`.
+///   - [sharingFilesStream] is subscribed to in `MobileScaffold.initState`
+///     for warm-start shares; emits raw local file paths.
+///   - [saveSharedImages] compresses and stores images; called from
+///     `ShareToEntryPage._addToEntry`.
+class ShareIntentService {
+  ShareIntentService._();
+  static final ShareIntentService instance = ShareIntentService._();
+
+  static const MethodChannel _channel =
+      MethodChannel('com.demizo.daily_you/share');
+
+  final StreamController<List<String>> _rawFilesController =
+      StreamController<List<String>>.broadcast();
+
+  /// Warm-start stream. Emits local file paths when a share arrives while the
+  /// app is already running. Subscribe in `MobileScaffold.initState`.
+  Stream<List<String>> get sharingFilesStream => _rawFilesController.stream;
+
+  bool _initialized = false;
+  String? _lastWarmStartKey;
+
+  /// Registers the warm-start MethodChannel handler.
+  ///
+  /// Safe to call multiple times — no-op after first call.
+  /// Call early in `main()` so no warm-start shares are missed.
+  void init() {
+    if (_initialized) return;
+    _initialized = true;
+
+    _channel.setMethodCallHandler((call) async {
+      if (call.method == 'onSharedFiles') {
+        final uris = _toUriList(call.arguments);
+        if (uris.isEmpty) return;
+        // Deduplicate: onNewIntent may fire on activity recreation.
+        final key = uris.join('|');
+        if (key == _lastWarmStartKey) return;
+        _lastWarmStartKey = key;
+        _rawFilesController.add(uris);
+      }
+    });
+  }
+
+  /// Returns raw file paths from the cold-start share intent, or `null` if
+  /// the app was not launched via a share action.
+  ///
+  /// Call after `AppDatabase.instance.init()` so the caller can safely route
+  /// to `ShareToEntryPage`.
+  Future<List<String>?> getInitialSharedFiles() async {
+    try {
+      final result =
+          await _channel.invokeMethod<dynamic>('getInitialSharedFiles');
+      final uris = _toUriList(result);
+      return uris.isEmpty ? null : uris;
+    } on PlatformException catch (e) {
+      debugPrint('ShareIntentService: getInitialSharedFiles failed: $e');
+      return null;
+    }
+  }
+
+  /// Compresses and stores images at [filePaths], returning [EntryImage]
+  /// records ready for `EntryImagesProvider.add`.
+  ///
+  /// Individual failures are silently skipped (partial-success behaviour).
+  Future<List<EntryImage>> saveSharedImages(
+      List<String> filePaths, int entryId) async {
+    final saved = <EntryImage>[];
+
+    for (int i = 0; i < filePaths.length; i++) {
+      final path = filePaths[i];
+      try {
+        final bytes = await _compressAndLoad(path);
+        final imageName =
+            await ImageStorage.instance.create(_fileNameHint(path), bytes);
+        if (imageName == null) continue;
+
+        saved.add(EntryImage(
+          entryId: entryId,
+          imgPath: imageName,
+          imgRank: filePaths.length - 1 - i,
+          timeCreate: DateTime.now(),
+        ));
+      } catch (e) {
+        debugPrint('ShareIntentService: failed to process $path: $e');
+      }
+    }
+
+    return saved;
+  }
+
+  /// Reads raw bytes from [uri].
+  ///
+  /// Handles both plain file paths and `content://` URIs — the latter are
+  /// read via the native MethodChannel since `File()` cannot open them on
+  /// Android. Used by [ShareImagePreview] for in-app image rendering.
+  Future<Uint8List?> readUriBytes(String uri) async {
+    try {
+      return await _readContentUri(uri);
+    } catch (e) {
+      debugPrint('ShareIntentService: readUriBytes failed for $uri: $e');
+      return null;
+    }
+  }
+
+  void dispose() {
+    // Clear the handler rather than closing the singleton StreamController,
+    // which cannot be reopened if the service is reused.
+    _channel.setMethodCallHandler(null);
+    _initialized = false;
+    _lastWarmStartKey = null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  List<String> _toUriList(dynamic raw) {
+    if (raw == null) return const [];
+    if (raw is List) return raw.whereType<String>().toList();
+    return const [];
+  }
+
+  /// Compression logic mirrors `entry_image_picker.dart:73-98` exactly.
+  Future<Uint8List> _compressAndLoad(String contentUri) async {
+    // Read raw bytes from the content:// URI via the native MethodChannel.
+    // File() cannot open content:// URIs on Android.
+    final rawBytes = await _readContentUri(contentUri);
+
+    final quality = ConfigProvider.instance.get(ConfigKey.imageQualityLevel);
+    // Derive a hint extension from the URI for GIF detection.
+    final ext = extension(contentUri.split('?').first).toLowerCase();
+
+    if (ext == '.gif' || quality == ImageQuality.noCompression) {
+      return rawBytes;
+    }
+
+    final width =
+        (ConfigProvider.imageQualityMaxSizeMapping[quality] ?? 1600).toInt();
+    final compressionQuality =
+        ConfigProvider.imageQualityCompressionMapping[quality] ?? 100;
+
+    if (Platform.isAndroid) {
+      return await FlutterImageCompress.compressWithList(
+            rawBytes,
+            quality: compressionQuality,
+            minWidth: width,
+            minHeight: width,
+          ) ??
+          rawBytes;
+    }
+
+    return rawBytes;
+  }
+
+  /// Reads bytes from a content:// URI via the native MethodChannel.
+  Future<Uint8List> _readContentUri(String uri) async {
+    // If it's already a plain file path, read directly.
+    if (!uri.startsWith('content://')) {
+      return File(uri).readAsBytes();
+    }
+    try {
+      final result = await _channel.invokeMethod<dynamic>(
+          'readFileBytes', {'uri': uri});
+      if (result is Uint8List) return result;
+      if (result is List) return Uint8List.fromList(result.cast<int>());
+      throw Exception('readFileBytes returned unexpected type: ${result.runtimeType}');
+    } on PlatformException catch (e) {
+      debugPrint('ShareIntentService: readFileBytes failed for $uri: $e');
+      rethrow;
+    }
+  }
+
+  String? _fileNameHint(String path) {
+    final segment = path.split('/').last.split('?').first;
+    return segment.isNotEmpty ? segment : null;
+  }
+}

--- a/lib/widgets/share_image_preview.dart
+++ b/lib/widgets/share_image_preview.dart
@@ -1,0 +1,94 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:daily_you/services/share_intent_service.dart';
+import 'package:flutter/material.dart';
+
+/// Displays a scrollable horizontal (or single-item) preview of images that
+/// are being shared into the app.
+///
+/// [paths] may be `content://` URIs (from Android) or plain file paths.
+/// `content://` URIs are read via the native MethodChannel so they render
+/// correctly without needing a temporary file copy.
+class ShareImagePreview extends StatelessWidget {
+  final List<String> paths;
+
+  const ShareImagePreview({super.key, required this.paths});
+
+  @override
+  Widget build(BuildContext context) {
+    if (paths.isEmpty) return const SizedBox.shrink();
+
+    final isSingle = paths.length == 1;
+
+    return SizedBox(
+      height: isSingle ? 240 : 180,
+      child: isSingle
+          ? _SharedImage(uri: paths.first, fit: BoxFit.contain)
+          : ListView.separated(
+              scrollDirection: Axis.horizontal,
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              itemCount: paths.length,
+              separatorBuilder: (_, __) => const SizedBox(width: 8),
+              itemBuilder: (context, index) => ClipRRect(
+                borderRadius: BorderRadius.circular(12),
+                child: AspectRatio(
+                  aspectRatio: 1,
+                  child: _SharedImage(uri: paths[index], fit: BoxFit.cover),
+                ),
+              ),
+            ),
+    );
+  }
+}
+
+/// Renders a single shared image from either a `content://` URI or a plain
+/// file path.
+///
+/// For `content://` URIs the bytes are fetched asynchronously via
+/// [ShareIntentService.readUriBytes] so that Android's `ContentResolver` is
+/// used instead of the `File` API (which cannot open content URIs).
+class _SharedImage extends StatelessWidget {
+  final String uri;
+  final BoxFit fit;
+
+  const _SharedImage({required this.uri, required this.fit});
+
+  bool get _isContentUri => uri.startsWith('content://');
+
+  Widget _brokenIcon(BuildContext context, Object? _, StackTrace? __) =>
+      Center(
+        child: Icon(
+          Icons.broken_image_rounded,
+          size: 36,
+          color: Theme.of(context).colorScheme.onSurfaceVariant,
+        ),
+      );
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_isContentUri) {
+      // Plain file path — use Image.file directly (no async needed).
+      return Image.file(
+        File(uri),
+        fit: fit,
+        errorBuilder: _brokenIcon,
+      );
+    }
+
+    // content:// URI — read bytes via the MethodChannel.
+    return FutureBuilder<Uint8List?>(
+      future: ShareIntentService.instance.readUriBytes(uri),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const Center(child: CircularProgressIndicator(strokeWidth: 2));
+        }
+        final bytes = snapshot.data;
+        if (bytes == null || bytes.isEmpty) {
+          return _brokenIcon(context, null, null);
+        }
+        return Image.memory(bytes, fit: fit, errorBuilder: _brokenIcon);
+      },
+    );
+  }
+}


### PR DESCRIPTION
### Description

  Add "Share to Daily You" to the Android share sheet. When triggered, a new page opens allowing the user to add the shared image to a diary entry — either today's or a date they pick.

  Closes #340

  ### Reasoning

  Used an Android `intent-filter` with `ACTION_SEND` + `image/*` MIME type to receive shares. A `MethodChannel` in `MainActivity`
  passes the content URI to Flutter. `ShareIntentService` converts the URI to a local file path, and `ShareToEntryPage` handles UI
  for date selection and saving to the entry via the existing `EntriesProvider` / `EntryImagesProvider` pattern.

  ### Testing

  1. Long-press an image in the gallery → share → select "Daily You" → verify page opens with image preview
  2. Select today → tap "Add to Entry" → verify image appears in today's diary entry
  3. Select a past date → tap "Add to Entry" → verify image is appended to that date's entry
  4. Share to a date with an existing entry → verify image is appended (not replaced)
  5. Tap back/cancel → verify no entry is created
  6. Test with app not running → verify app launches directly to the share page

  ### Type of change

  :x: **Bug fix**
  :white_check_mark: **New feature** (A non-breaking change that adds functionality)
  :x: **Breaking change**
  :x: **Refactor**
  :x: **Performance**
  :x: **Style**
  :x: **Docs**
  :x: **Chore**