### PR TITLE
feat: saf transfer

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -143,5 +143,6 @@ flutter {
 dependencies {
     implementation 'androidx.window:window:1.0.0'
     implementation 'androidx.window:window-java:1.0.0'
+    implementation("androidx.documentfile:documentfile:1.1.0")
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.4'
 }

--- a/android/app/src/main/kotlin/com/example/daily_you/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/daily_you/MainActivity.kt
@@ -1,10 +1,17 @@
 package com.demizo.daily_you
 
 import io.flutter.embedding.android.FlutterFragmentActivity
+import io.flutter.embedding.engine.FlutterEngine
+import SafTransferPlugin
 import android.content.Intent;
 
 class MainActivity: FlutterFragmentActivity() {
   override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
     super.onActivityResult(requestCode, resultCode, data)
+  }
+
+  override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+    super.configureFlutterEngine(flutterEngine)
+    flutterEngine.plugins.add(SafTransferPlugin())
   }
 }

--- a/android/app/src/main/kotlin/com/example/daily_you/SafTransferPlugin.kt
+++ b/android/app/src/main/kotlin/com/example/daily_you/SafTransferPlugin.kt
@@ -1,0 +1,147 @@
+import android.content.Context
+import androidx.documentfile.provider.DocumentFile
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.MethodChannel.MethodCallHandler
+import io.flutter.plugin.common.MethodChannel.Result
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileInputStream
+import java.io.InputStream
+import java.io.OutputStream
+import androidx.core.net.toUri
+
+class SafTransferPlugin : FlutterPlugin, MethodCallHandler {
+    private lateinit var channel: MethodChannel
+    private lateinit var context: Context
+
+    override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
+        context = flutterPluginBinding.applicationContext
+        channel = MethodChannel(flutterPluginBinding.binaryMessenger, "saf_transfer")
+        channel.setMethodCallHandler(this)
+    }
+
+    override fun onMethodCall(call: MethodCall, result: Result) {
+        when (call.method) {
+            "copyFromExternal" -> {
+                CoroutineScope(Dispatchers.IO).launch {
+                    try {
+                        val fileUriStr = call.argument<String>("src")!!.toUri()
+                        val dest = call.argument<String>("dest")!!
+                        val transferId = call.argument<String>("transferId")!!
+
+                        // Get file size for progress calculation
+                        val totalSize = DocumentFile.fromSingleUri(context, fileUriStr)?.length() ?: 0L
+                        val inputStream = context.contentResolver.openInputStream(fileUriStr)
+                        
+                        inputStream?.use { input ->
+                            val file = File(dest)
+                            file.outputStream().use { output ->
+                                copyStreamWithProgress(input, output, totalSize, transferId)
+                            }
+                        }
+                        
+                        launch(Dispatchers.Main) { result.success(null) }
+                    } catch (err: Exception) {
+                        launch(Dispatchers.Main) { result.error("PluginError", err.message, null) }
+                    }
+                }
+            }
+
+            "copyToExternal" -> {
+                CoroutineScope(Dispatchers.IO).launch {
+                    try {
+                        val treeUriStr = call.argument<String>("treeUri")!!
+                        val fileName = call.argument<String>("fileName")!!
+                        val mime = call.argument<String>("mime")!!
+                        val localSrc = call.argument<String>("localSrc")!!
+                        val overwrite = call.argument<Boolean>("overwrite")!!
+                        val append = call.argument<Boolean>("append")!!
+                        val transferId = call.argument<String>("transferId")!!
+
+                        val totalSize = File(localSrc).length()
+                        val dir = DocumentFile.fromTreeUri(context, treeUriStr.toUri())
+                            ?: throw Exception("Directory not found")
+
+                        val (newFile, outStream) = createOutStream(dir, fileName, mime, overwrite, append)
+                        val inStream = FileInputStream(File(localSrc))
+
+                        val map = HashMap<String, Any?>()
+                        map["uri"] = newFile.uri.toString()
+                        map["fileName"] = newFile.name
+
+                        inStream.use { input ->
+                            outStream.use { output ->
+                                copyStreamWithProgress(input, output, totalSize, transferId)
+                            }
+                        }
+
+                        launch(Dispatchers.Main) { result.success(map) }
+                    } catch (err: Exception) {
+                        launch(Dispatchers.Main) { result.error("PluginError", err.message, null) }
+                    }
+                }
+            }
+            else -> result.notImplemented()
+        }
+    }
+
+    override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        channel.setMethodCallHandler(null)
+    }
+
+    private suspend fun copyStreamWithProgress(
+        input: InputStream, 
+        output: OutputStream, 
+        totalSize: Long, 
+        transferId: String
+    ) {
+        val buffer = ByteArray(8 * 1024)
+        var bytesRead: Int
+        var totalRead: Long = 0
+        var lastReportedProgress = 0.0
+
+        while (input.read(buffer).also { bytesRead = it } >= 0) {
+            output.write(buffer, 0, bytesRead)
+            totalRead += bytesRead
+
+            if (totalSize > 0) {
+                val currentProgress = (totalRead.toDouble() / totalSize) * 100
+                
+                // Report progress every ~5% or when finished
+                if (currentProgress - lastReportedProgress >= 5.0 || currentProgress >= 100.0) {
+                    lastReportedProgress = currentProgress
+                    
+                    // Flutter MethodChannel requires UI Thread
+                    withContext(Dispatchers.Main) {
+                        channel.invokeMethod("transferProgress", mapOf(
+                            "id" to transferId,
+                            "progress" to currentProgress
+                        ))
+                    }
+                }
+            }
+        }
+    }
+
+    private fun createOutStream(dir: DocumentFile, fileName: String, mime: String, overwrite: Boolean, append: Boolean) : Pair<DocumentFile, OutputStream> {
+        val outStream: OutputStream
+        val newFile: DocumentFile
+        if (overwrite || append) {
+            val curFile = dir.findFile(fileName)
+            newFile = curFile ?: dir.createFile(mime, fileName) ?: throw Exception("File creation failed at $fileName (createOutStream, overwrite=$overwrite, append=$append)")
+            outStream = context.contentResolver.openOutputStream(newFile.uri, if (append) "wa" else "wt")
+                ?: throw Exception("Stream creation failed at $fileName (createOutStream, overwrite=$overwrite, append=$append")
+        } else {
+            newFile = dir.createFile(mime, fileName)
+                ?: throw Exception("File creation failed at $fileName (createOutStream, overwrite=0")
+            outStream = context.contentResolver.openOutputStream(newFile.uri)
+                ?: throw Exception("Stream creation failed at $fileName (createOutStream, overwrite=0")
+        }
+        return Pair(newFile, outStream)
+    }
+}

--- a/lib/file_layer.dart
+++ b/lib/file_layer.dart
@@ -1,19 +1,10 @@
 import 'dart:io';
 import 'dart:typed_data';
+import 'package:daily_you/utils/saf_transfer.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:path/path.dart';
-import 'package:saf_stream/saf_stream.dart';
-import 'package:saf_stream/saf_stream_platform_interface.dart';
 import 'package:saf_util/saf_util.dart';
 import 'package:shared_storage/shared_storage.dart' as saf;
-
-class FileLayerWriteStream {
-  final bool useSaf;
-  final SafWriteStreamInfo? safStream;
-  final IOSink? sink;
-
-  const FileLayerWriteStream({required this.useSaf, this.safStream, this.sink});
-}
 
 class FileLayer {
   static Future<String?> pickDirectory() async {
@@ -96,51 +87,6 @@ class FileLayer {
       // Desktop
       var targetFile = File(join(uri, name));
       return await targetFile.exists() ? await targetFile.readAsBytes() : null;
-    }
-  }
-
-  static Future<Stream<List<int>>?> readFileStream(String uri,
-      {String? name, useExternalPath = true}) async {
-    if (Platform.isAndroid && useExternalPath) {
-      // Android
-      return await SafStream().readFileStream(uri);
-    } else {
-      // Desktop
-      var targetFile = File(join(uri, name));
-      return await targetFile.exists() ? targetFile.openRead() : null;
-    }
-  }
-
-  static Future<FileLayerWriteStream?> openFileWriteStream(
-      String uri, String name,
-      {overwrite = true, useExternalPath = true}) async {
-    if (Platform.isAndroid && useExternalPath) {
-      // Android
-      var stream =
-          await SafStream().startWriteStream(uri, name, 'application/zip');
-      return FileLayerWriteStream(useSaf: true, safStream: stream);
-    } else {
-      // Desktop
-      var targetFile = File(join(uri, name));
-      return FileLayerWriteStream(useSaf: false, sink: targetFile.openWrite());
-    }
-  }
-
-  static Future<void> writeFileWriteStreamChunk(
-      FileLayerWriteStream stream, Uint8List data) async {
-    if (stream.useSaf) {
-      await SafStream().writeChunk(stream.safStream!.session, data);
-    } else {
-      stream.sink!.add(data);
-      await stream.sink!.flush();
-    }
-  }
-
-  static Future<void> closeFileWriteStream(FileLayerWriteStream stream) async {
-    if (stream.useSaf) {
-      await SafStream().endWriteStream(stream.safStream!.session);
-    } else {
-      await stream.sink!.close();
     }
   }
 
@@ -285,58 +231,79 @@ class FileLayer {
   static Future<bool> copyFromExternalLocation(
       String externalFile, String internalFolder, String outputFile,
       {Function(double percent)? onProgress}) async {
-    final fileSize = await FileLayer.getFileSize(externalFile);
-    if (fileSize == null || fileSize == 0) return false;
+    if (Platform.isAndroid) {
+      return await SafTransfer.copyFromExternalLocation(
+          externalFile, join(internalFolder, outputFile),
+          onProgress: onProgress);
+    } else {
+      // Desktop file streaming
+      final sourceFile = File(externalFile);
+      if (!await sourceFile.exists()) return false;
 
-    var readStream =
-        await FileLayer.readFileStream(externalFile, useExternalPath: true);
-    if (readStream == null) return false;
-    var writeStream = await FileLayer.openFileWriteStream(
-        internalFolder, outputFile,
-        useExternalPath: false);
-    if (writeStream == null) return false;
+      final fileSize = await sourceFile.length();
+      if (fileSize == 0) return false;
 
-    var transferredSize = 0;
+      final destFile = File(join(internalFolder, outputFile));
+      final writeSink = destFile.openWrite();
 
-    await for (List<int> chunk in readStream) {
-      await FileLayer.writeFileWriteStreamChunk(
-          writeStream, Uint8List.fromList(chunk));
-      transferredSize += chunk.length;
-      var percent = (transferredSize / fileSize) * 100;
-      if (onProgress != null) {
-        onProgress(percent);
+      var transferredSize = 0;
+      var lastReportedProgress = 0.0;
+
+      await for (List<int> chunk in sourceFile.openRead()) {
+        writeSink.add(chunk);
+        transferredSize += chunk.length;
+
+        var percent = (transferredSize / fileSize) * 100;
+        if (percent - lastReportedProgress >= 5.0 || percent >= 100.0) {
+          lastReportedProgress = percent;
+          if (onProgress != null) {
+            onProgress(percent);
+          }
+        }
       }
+
+      await writeSink.flush();
+      await writeSink.close();
+      return true;
     }
-    await FileLayer.closeFileWriteStream(writeStream);
-    return true;
   }
 
   static Future<bool> copyToExternalLocation(
       String localFile, String externalFolder, String outputFile,
       {Function(double percent)? onProgress}) async {
-    final fileSize =
-        await FileLayer.getFileSize(localFile, useExternalPath: false);
-    if (fileSize == null || fileSize == 0) return false;
+    if (Platform.isAndroid) {
+      return await SafTransfer.copyToExternalLocation(
+          localFile, externalFolder, outputFile, "application/zip",
+          onProgress: onProgress);
+    } else {
+      final sourceFile = File(localFile);
+      if (!await sourceFile.exists()) return false;
 
-    var readStream =
-        await FileLayer.readFileStream(localFile, useExternalPath: false);
-    if (readStream == null) return false;
-    var writeStream =
-        await FileLayer.openFileWriteStream(externalFolder, outputFile);
-    if (writeStream == null) return false;
+      final fileSize = await sourceFile.length();
+      if (fileSize == 0) return false;
 
-    var transferredSize = 0;
+      final destFile = File(join(externalFolder, outputFile));
+      final writeSink = destFile.openWrite();
 
-    await for (List<int> chunk in readStream) {
-      await FileLayer.writeFileWriteStreamChunk(
-          writeStream, Uint8List.fromList(chunk));
-      transferredSize += chunk.length;
-      var percent = (transferredSize / fileSize) * 100;
-      if (onProgress != null) {
-        onProgress(percent);
+      var transferredSize = 0;
+      var lastReportedProgress = 0.0;
+
+      await for (List<int> chunk in sourceFile.openRead()) {
+        writeSink.add(chunk);
+        transferredSize += chunk.length;
+
+        var percent = (transferredSize / fileSize) * 100;
+        if (percent - lastReportedProgress >= 5.0 || percent >= 100.0) {
+          lastReportedProgress = percent;
+          if (onProgress != null) {
+            onProgress(percent);
+          }
+        }
       }
+
+      await writeSink.flush();
+      await writeSink.close();
+      return true;
     }
-    await FileLayer.closeFileWriteStream(writeStream);
-    return true;
   }
 }

--- a/lib/pages/launch_page.dart
+++ b/lib/pages/launch_page.dart
@@ -33,10 +33,14 @@ class _LaunchPageState extends State<LaunchPage> {
     if (!_initialized) {
       _initialized = true;
 
-      _storeLocalizedNotificationStrings();
-      _updateAppShortcuts();
-      _checkDatabaseConnection();
+      _initializeApp();
     }
+  }
+
+  _initializeApp() async {
+    await _storeLocalizedNotificationStrings();
+    await _updateAppShortcuts();
+    await _checkDatabaseConnection();
   }
 
   _updateAppShortcuts() async {

--- a/lib/utils/saf_transfer.dart
+++ b/lib/utils/saf_transfer.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/services.dart';
+import 'package:uuid/uuid.dart';
+
+class SafTransfer {
+  static const MethodChannel _channel = MethodChannel('saf_transfer');
+
+  // A map to hold active progress callbacks referenced by their transfer ID
+  static final Map<String, Function(double)> _progressCallbacks = {};
+  static bool _isInitialized = false;
+
+  /// Initialize the listener once
+  static void _initListener() {
+    if (_isInitialized) return;
+
+    _channel.setMethodCallHandler((call) async {
+      if (call.method == 'transferProgress') {
+        final String id = call.arguments['id'];
+        final double progress = call.arguments['progress'];
+
+        if (_progressCallbacks.containsKey(id)) {
+          _progressCallbacks[id]!(progress);
+        }
+      }
+    });
+
+    _isInitialized = true;
+  }
+
+  /// Copy a file from external storage to local storage
+  static Future<bool> copyFromExternalLocation(
+      String externalFileUri, String localDestPath,
+      {Function(double percent)? onProgress}) async {
+    _initListener();
+    final transferId = const Uuid().v4();
+
+    if (onProgress != null) {
+      _progressCallbacks[transferId] = onProgress;
+    }
+
+    try {
+      await _channel.invokeMethod('copyFromExternal', {
+        'src': externalFileUri,
+        'dest': localDestPath,
+        'transferId': transferId,
+      });
+
+      // Ensure 100% is fired at completion
+      if (onProgress != null) onProgress(100.0);
+      return true;
+    } catch (e) {
+      return false;
+    } finally {
+      // Clean up callback memory to prevent leaks
+      _progressCallbacks.remove(transferId);
+    }
+  }
+
+  /// Copy a file from local storage to external storage (SAF)
+  static Future<bool> copyToExternalLocation(
+      String localFilePath, String treeUri, String fileName, String mimeType,
+      {bool overwrite = false,
+      bool append = false,
+      Function(double percent)? onProgress}) async {
+    _initListener();
+    final transferId = const Uuid().v4();
+
+    if (onProgress != null) {
+      _progressCallbacks[transferId] = onProgress;
+    }
+
+    try {
+      final result = await _channel.invokeMethod('copyToExternal', {
+        'treeUri': treeUri,
+        'fileName': fileName,
+        'mime': mimeType,
+        'localSrc': localFilePath,
+        'overwrite': overwrite,
+        'append': append,
+        'transferId': transferId,
+      });
+
+      if (onProgress != null) onProgress(100.0);
+      return result != null;
+    } catch (e) {
+      return false;
+    } finally {
+      _progressCallbacks.remove(transferId);
+    }
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1027,14 +1027,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.1"
-  sprintf:
-    dependency: transitive
-    description:
-      name: sprintf
-      sha256: "1fc9ffe69d4df602376b52949af107d8f5703b77cda567c4d7d86a0693120f23"
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.0.0"
   sqflite:
     dependency: "direct main"
     description:
@@ -1276,13 +1268,13 @@ packages:
     source: hosted
     version: "3.1.4"
   uuid:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: uuid
-      sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff
+      sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.1"
+    version: "4.5.3"
   vector_graphics:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,6 +63,7 @@ dependencies:
   quick_actions: ^1.1.0
   flutter_displaymode: ^0.7.0
   dynamic_color: ^1.8.1
+  uuid: ^4.5.3
 dev_dependencies:
   flutter_lints: ^5.0.0
 


### PR DESCRIPTION
Add a custom SAF transfer implementation. The transfer occurs entirely in native code to avoid memory overflows when passing buffers to dart faster than they are processed.

closes #331