### PR TITLE
feat: remove "no mood" icon

### DIFF
--- a/lib/config_provider.dart
+++ b/lib/config_provider.dart
@@ -27,7 +27,6 @@ class ConfigKey {
   static const String neutralIcon = "neutralIcon";
   static const String sadIcon = "sadIcon";
   static const String verySadIcon = "verySadIcon";
-  static const String noMoodIcon = "noMoodIcon";
   static const String followSystemColor = "followSystemColor";
   static const String accentColor = "accentColor";
   static const String dailyReminders = "dailyReminders";
@@ -70,6 +69,7 @@ class ConfigKey {
   static const String imageQuality = "imageQuality";
   static const String homePageViewMode = "homePageViewMode";
   static const String calendarViewMode = "calendarViewMode";
+  static const String noMoodIcon = "noMoodIcon";
 }
 
 class ImageQuality {
@@ -102,7 +102,6 @@ class ConfigProvider with ChangeNotifier {
     ConfigKey.neutralIcon: '😐',
     ConfigKey.sadIcon: '😕',
     ConfigKey.verySadIcon: '😔',
-    ConfigKey.noMoodIcon: '?',
     ConfigKey.followSystemColor: true,
     ConfigKey.accentColor: 0xff62A0EA,
     ConfigKey.dailyReminders: false,
@@ -157,7 +156,6 @@ class ConfigProvider with ChangeNotifier {
     ConfigKey.neutralIcon: '😐',
     ConfigKey.sadIcon: '😕',
     ConfigKey.verySadIcon: '😔',
-    ConfigKey.noMoodIcon: '?',
   };
 
   static final imageQualityCompressionMapping = {

--- a/lib/pages/settings/appearance_settings.dart
+++ b/lib/pages/settings/appearance_settings.dart
@@ -92,9 +92,6 @@ class _AppearanceSettingsPageState extends State<AppearanceSettings> {
                   if (value != null) {
                     await ConfigProvider.instance.set(
                         ConfigProvider.moodValueFieldMapping[value]!, newEmoji);
-                  } else {
-                    await ConfigProvider.instance
-                        .set(ConfigKey.noMoodIcon, newEmoji);
                   }
                 }
                 if (!context.mounted) return;
@@ -124,8 +121,7 @@ class _AppearanceSettingsPageState extends State<AppearanceSettings> {
       context: context,
       builder: (BuildContext context) {
         return AlertDialog(
-          title:
-              Text(AppLocalizations.of(context)!.settingsHideImages),
+          title: Text(AppLocalizations.of(context)!.settingsHideImages),
           content: StatefulBuilder(
             builder: (context, setDialogState) {
               return Column(
@@ -136,7 +132,8 @@ class _AppearanceSettingsPageState extends State<AppearanceSettings> {
                     AppLocalizations.of(context)!.flashbacksTitle,
                     configProvider.get(ConfigKey.hideImagesInFlashbacks),
                     (value) {
-                      configProvider.set(ConfigKey.hideImagesInFlashbacks, value);
+                      configProvider.set(
+                          ConfigKey.hideImagesInFlashbacks, value);
                       setDialogState(() {});
                     },
                   ),
@@ -164,8 +161,7 @@ class _AppearanceSettingsPageState extends State<AppearanceSettings> {
           ),
           actions: [
             TextButton(
-              child:
-                  Text(MaterialLocalizations.of(context).okButtonLabel),
+              child: Text(MaterialLocalizations.of(context).okButtonLabel),
               onPressed: () => Navigator.pop(context),
             ),
           ],
@@ -346,7 +342,6 @@ class _AppearanceSettingsPageState extends State<AppearanceSettings> {
                     moodIconButton(0),
                     moodIconButton(1),
                     moodIconButton(2),
-                    moodIconButton(null),
                   ],
                 ),
                 IconButton(

--- a/lib/widgets/mood_icon.dart
+++ b/lib/widgets/mood_icon.dart
@@ -22,7 +22,7 @@ class MoodIcon extends StatefulWidget {
       moodIcon = ConfigProvider.instance
           .get(ConfigProvider.moodValueFieldMapping[moodValue]!);
     }
-    return moodIcon ?? ConfigProvider.instance.get(ConfigKey.noMoodIcon);
+    return moodIcon ?? "";
   }
 }
 


### PR DESCRIPTION
There were very few remaining places where this was used. It created confusion in the settings as it looked like the option to add a mood. No mood icon at all makes more sense than a custom icon for a missing mood.