### PR TITLE
feat: improve flashbacks without images

### DIFF
--- a/lib/widgets/entry_card_widget.dart
+++ b/lib/widgets/entry_card_widget.dart
@@ -59,6 +59,7 @@ class EntryCardWidget extends StatelessWidget {
                                 child: ScaledMarkdown(
                                   data: entry.text,
                                   maxCharacters: 250,
+                                  scaleFactor: 0.95,
                                 ),
                               ))
                             ]),

--- a/lib/widgets/entry_card_widget.dart
+++ b/lib/widgets/entry_card_widget.dart
@@ -35,6 +35,7 @@ class EntryCardWidget extends StatelessWidget {
         children: [
           Expanded(
             child: ClipRRect(
+              clipBehavior: Clip.hardEdge,
               borderRadius: BorderRadius.circular(12),
               child: (images.isNotEmpty && !hideImage)
                   ? ImageGrid(images: images)
@@ -55,7 +56,10 @@ class EntryCardWidget extends StatelessWidget {
                               IgnorePointer(
                                   child: SizedBox(
                                 width: double.maxFinite,
-                                child: ScaledMarkdown(data: entry.text),
+                                child: ScaledMarkdown(
+                                  data: entry.text,
+                                  maxCharacters: 250,
+                                ),
                               ))
                             ]),
                           ),

--- a/lib/widgets/flashback_card.dart
+++ b/lib/widgets/flashback_card.dart
@@ -54,7 +54,7 @@ class FlashbackCard extends StatelessWidget {
                           begin: Alignment.topCenter,
                           end: Alignment.bottomCenter,
                           colors: [Colors.black, Colors.transparent],
-                          stops: [0.65, 0.75],
+                          stops: [0.60, 0.75],
                         ).createShader(bounds);
                       },
                       blendMode: BlendMode.dstIn,
@@ -70,7 +70,9 @@ class FlashbackCard extends StatelessWidget {
                                 child: (text.isNotEmpty)
                                     ? ScaledMarkdown(
                                         data: text,
-                                        maxCharacters: 100,
+                                        maxCharacters: 120,
+                                        scaleFactor: 0.9,
+                                        compact: true,
                                       )
                                     : Text(
                                         AppLocalizations.of(

--- a/lib/widgets/flashback_card.dart
+++ b/lib/widgets/flashback_card.dart
@@ -1,3 +1,4 @@
+import 'package:daily_you/l10n/generated/app_localizations.dart';
 import 'package:daily_you/config_provider.dart';
 import 'package:daily_you/models/entry.dart';
 import 'package:daily_you/models/image.dart';
@@ -21,6 +22,8 @@ class FlashbackCard extends StatelessWidget {
     final imagesProvider = EntryImagesProvider.instance;
     final hideImages =
         ConfigProvider.instance.get(ConfigKey.hideImagesInFlashbacks) == true;
+    final theme = Theme.of(context);
+    final text = entries.first.text;
 
     final coverImages = hideImages
         ? <EntryImage>[]
@@ -36,36 +39,52 @@ class FlashbackCard extends StatelessWidget {
     return AspectRatio(
       aspectRatio: 3.7 / 4,
       child: Card.filled(
-        color: Theme.of(context).colorScheme.surfaceContainer,
+        color: theme.colorScheme.surfaceContainer,
         clipBehavior: Clip.antiAlias,
         child: Stack(
           fit: StackFit.expand,
           children: [
             hasImages
                 ? ImageGrid(images: coverImages)
-                : ShaderMask(
-                    shaderCallback: (Rect bounds) {
-                      return const LinearGradient(
-                        begin: Alignment.topCenter,
-                        end: Alignment.bottomCenter,
-                        colors: [Colors.black, Colors.transparent],
-                        stops: [0.70, 0.75],
-                      ).createShader(bounds);
-                    },
-                    blendMode: BlendMode.dstIn,
-                    child: Padding(
-                      padding: const EdgeInsets.all(8.0),
-                      child: Wrap(children: [
-                        IgnorePointer(
-                            child: SizedBox(
-                          width: double.maxFinite,
-                          child: Padding(
-                            padding:
-                                EdgeInsets.only(top: showCount ? 20.0 : 0.0),
-                            child: ScaledMarkdown(data: entries.first.text),
-                          ),
-                        ))
-                      ]),
+                : ClipRect(
+                    clipBehavior: Clip.hardEdge,
+                    child: ShaderMask(
+                      shaderCallback: (Rect bounds) {
+                        return const LinearGradient(
+                          begin: Alignment.topCenter,
+                          end: Alignment.bottomCenter,
+                          colors: [Colors.black, Colors.transparent],
+                          stops: [0.65, 0.75],
+                        ).createShader(bounds);
+                      },
+                      blendMode: BlendMode.dstIn,
+                      child: Padding(
+                        padding: const EdgeInsets.all(8.0),
+                        child: Wrap(children: [
+                          IgnorePointer(
+                              child: SizedBox(
+                            width: double.maxFinite,
+                            child: Padding(
+                                padding: EdgeInsets.only(
+                                    top: showCount ? 20.0 : 0.0),
+                                child: (text.isNotEmpty)
+                                    ? ScaledMarkdown(
+                                        data: text,
+                                        maxCharacters: 100,
+                                      )
+                                    : Text(
+                                        AppLocalizations.of(
+                                          context,
+                                        )!
+                                            .writeSomethingHint,
+                                        style: TextStyle(
+                                          color: theme.disabledColor,
+                                          fontSize: 16,
+                                        ),
+                                      )),
+                          ))
+                        ]),
+                      ),
                     ),
                   ),
             if (hasImages)
@@ -86,7 +105,7 @@ class FlashbackCard extends StatelessWidget {
                       style: TextStyle(
                         color: hasImages
                             ? Colors.white
-                            : Theme.of(context).colorScheme.onSurface,
+                            : theme.colorScheme.onSurface,
                         fontSize: 14,
                         fontWeight: FontWeight.bold,
                       ),
@@ -113,7 +132,7 @@ class FlashbackCard extends StatelessWidget {
                             decoration: BoxDecoration(
                               color: hasImages
                                   ? Colors.white
-                                  : Theme.of(context).colorScheme.onSurface,
+                                  : theme.colorScheme.onSurface,
                               shape: BoxShape.circle,
                             ),
                             child: Center(

--- a/lib/widgets/flashback_card.dart
+++ b/lib/widgets/flashback_card.dart
@@ -91,8 +91,10 @@ class FlashbackCard extends StatelessWidget {
                           child: Container(
                             height: 20,
                             width: 20,
-                            decoration: const BoxDecoration(
-                              color: Colors.white,
+                            decoration: BoxDecoration(
+                              color: hasImages
+                                  ? Colors.white
+                                  : Theme.of(context).colorScheme.onSurface,
                               shape: BoxShape.circle,
                             ),
                             child: Center(

--- a/lib/widgets/flashback_card.dart
+++ b/lib/widgets/flashback_card.dart
@@ -3,6 +3,7 @@ import 'package:daily_you/models/entry.dart';
 import 'package:daily_you/models/image.dart';
 import 'package:daily_you/providers/entry_images_provider.dart';
 import 'package:daily_you/widgets/image_grid.dart';
+import 'package:daily_you/widgets/scaled_markdown.dart';
 import 'package:flutter/material.dart';
 
 class FlashbackCard extends StatelessWidget {
@@ -42,11 +43,29 @@ class FlashbackCard extends StatelessWidget {
           children: [
             hasImages
                 ? ImageGrid(images: coverImages)
-                : Center(
-                    child: Icon(
-                      Icons.history_rounded,
-                      color: Theme.of(context).disabledColor,
-                      size: 36,
+                : ShaderMask(
+                    shaderCallback: (Rect bounds) {
+                      return const LinearGradient(
+                        begin: Alignment.topCenter,
+                        end: Alignment.bottomCenter,
+                        colors: [Colors.black, Colors.transparent],
+                        stops: [0.70, 0.75],
+                      ).createShader(bounds);
+                    },
+                    blendMode: BlendMode.dstIn,
+                    child: Padding(
+                      padding: const EdgeInsets.all(8.0),
+                      child: Wrap(children: [
+                        IgnorePointer(
+                            child: SizedBox(
+                          width: double.maxFinite,
+                          child: Padding(
+                            padding:
+                                EdgeInsets.only(top: showCount ? 20.0 : 0.0),
+                            child: ScaledMarkdown(data: entries.first.text),
+                          ),
+                        ))
+                      ]),
                     ),
                   ),
             if (hasImages)

--- a/lib/widgets/large_entry_card_widget.dart
+++ b/lib/widgets/large_entry_card_widget.dart
@@ -92,6 +92,7 @@ class LargeEntryCardWidget extends StatelessWidget {
                                   child: ScaledMarkdown(
                                     data: entry.text,
                                     maxCharacters: 500,
+                                    scaleFactor: 0.95,
                                   ),
                                 )
                               : Text(

--- a/lib/widgets/large_entry_card_widget.dart
+++ b/lib/widgets/large_entry_card_widget.dart
@@ -9,12 +9,13 @@ import 'package:daily_you/models/entry.dart';
 import 'package:daily_you/widgets/mood_icon.dart';
 
 class LargeEntryCardWidget extends StatelessWidget {
-  const LargeEntryCardWidget(
-      {super.key,
-      this.title,
-      required this.entry,
-      required this.images,
-      this.hideImage = false});
+  const LargeEntryCardWidget({
+    super.key,
+    this.title,
+    required this.entry,
+    required this.images,
+    this.hideImage = false,
+  });
 
   final Entry entry;
   final List<EntryImage> images;
@@ -24,8 +25,9 @@ class LargeEntryCardWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final time = DateFormat.yMMMd(TimeManager.currentLocale(context))
-        .format(entry.timeCreate);
+    final time = DateFormat.yMMMd(
+      TimeManager.currentLocale(context),
+    ).format(entry.timeCreate);
     return Card.filled(
       color: Theme.of(context).colorScheme.surfaceContainer,
       clipBehavior: Clip.antiAlias,
@@ -36,9 +38,11 @@ class LargeEntryCardWidget extends StatelessWidget {
         children: [
           if (images.isNotEmpty && !hideImage)
             Expanded(
-                child: ClipRRect(
-                    borderRadius: BorderRadius.circular(12),
-                    child: ImageGrid(images: images))),
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(12),
+                child: ImageGrid(images: images),
+              ),
+            ),
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -53,15 +57,14 @@ class LargeEntryCardWidget extends StatelessWidget {
                         child: Text(
                           title == null ? time : title!,
                           style: TextStyle(
-                              color: theme.textTheme.labelSmall?.color,
-                              fontWeight: FontWeight.bold),
+                            color: theme.textTheme.labelSmall?.color,
+                            fontWeight: FontWeight.bold,
+                          ),
                         ),
                       ),
                       Container(
                         constraints: const BoxConstraints(minWidth: 16),
-                        child: MoodIcon(
-                          moodValue: entry.mood,
-                        ),
+                        child: MoodIcon(moodValue: entry.mood),
                       ),
                     ],
                   ),
@@ -77,20 +80,31 @@ class LargeEntryCardWidget extends StatelessWidget {
                       ).createShader(bounds);
                     },
                     blendMode: BlendMode.dstIn,
-                    child: Padding(
-                      padding: const EdgeInsets.only(left: 8.0, right: 8.0),
-                      child: IgnorePointer(
-                        child: (entry.text.isNotEmpty)
-                            ? OverflowBox(
-                                alignment: AlignmentDirectional.topStart,
-                                maxHeight: double.infinity,
-                                child: ScaledMarkdown(data: entry.text))
-                            : Text(
-                                AppLocalizations.of(context)!
-                                    .writeSomethingHint,
-                                style: TextStyle(
-                                    color: theme.disabledColor, fontSize: 16),
-                              ),
+                    child: ClipRect(
+                      clipBehavior: Clip.hardEdge,
+                      child: Padding(
+                        padding: const EdgeInsets.only(left: 8.0, right: 8.0),
+                        child: IgnorePointer(
+                          child: (entry.text.isNotEmpty)
+                              ? OverflowBox(
+                                  alignment: AlignmentDirectional.topStart,
+                                  maxHeight: double.infinity,
+                                  child: ScaledMarkdown(
+                                    data: entry.text,
+                                    maxCharacters: 500,
+                                  ),
+                                )
+                              : Text(
+                                  AppLocalizations.of(
+                                    context,
+                                  )!
+                                      .writeSomethingHint,
+                                  style: TextStyle(
+                                    color: theme.disabledColor,
+                                    fontSize: 16,
+                                  ),
+                                ),
+                        ),
                       ),
                     ),
                   ),

--- a/lib/widgets/scaled_markdown.dart
+++ b/lib/widgets/scaled_markdown.dart
@@ -14,16 +14,19 @@ class ScaledMarkdown extends StatelessWidget {
       config: theme.brightness == Brightness.light
           ? MarkdownConfig.defaultConfig
           : MarkdownConfig.darkConfig,
-      generator: MarkdownGenerator(richTextBuilder: (span) {
-        return Builder(builder: (context) {
-          final shouldIgnoreTextScaler =
-              context.getInheritedWidgetOfExactType<_WithTextScalar>() != null;
-          final child = Text.rich(span);
-          return shouldIgnoreTextScaler
-              ? MediaQuery.withNoTextScaling(child: child)
-              : _WithTextScalar(child: child);
-        });
-      }),
+      generator: MarkdownGenerator(
+          richTextBuilder: (span) {
+            return Builder(builder: (context) {
+              final shouldIgnoreTextScaler =
+                  context.getInheritedWidgetOfExactType<_WithTextScalar>() !=
+                      null;
+              final child = Text.rich(span);
+              return shouldIgnoreTextScaler
+                  ? MediaQuery.withNoTextScaling(child: child)
+                  : _WithTextScalar(child: child);
+            });
+          },
+          linesMargin: EdgeInsets.only(bottom: 8, top: 2)),
       data: data,
     );
   }

--- a/lib/widgets/scaled_markdown.dart
+++ b/lib/widgets/scaled_markdown.dart
@@ -6,7 +6,16 @@ import 'package:markdown_widget/markdown_widget.dart';
 class ScaledMarkdown extends StatelessWidget {
   final String data;
   final int? maxCharacters;
-  const ScaledMarkdown({super.key, required this.data, this.maxCharacters});
+  final double scaleFactor;
+  final bool compact;
+
+  const ScaledMarkdown({
+    super.key,
+    required this.data,
+    this.maxCharacters,
+    this.scaleFactor = 1,
+    this.compact = false,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -17,23 +26,37 @@ class ScaledMarkdown extends StatelessWidget {
       text = "${text.substring(0, maxCharacters)}…";
     }
 
+    // Get the device's current text scaling to respect user settings
+    final deviceScaler = MediaQuery.textScalerOf(context);
+    // Apply custom scaling to the user's text scale
+    final customScaler = TextScaler.linear(deviceScaler.scale(scaleFactor));
+
     return MarkdownBlock(
       config: theme.brightness == Brightness.light
           ? MarkdownConfig.defaultConfig
           : MarkdownConfig.darkConfig,
       generator: MarkdownGenerator(
-          richTextBuilder: (span) {
-            return Builder(builder: (context) {
-              final shouldIgnoreTextScaler =
-                  context.getInheritedWidgetOfExactType<_WithTextScalar>() !=
-                      null;
-              final child = Text.rich(span);
-              return shouldIgnoreTextScaler
-                  ? MediaQuery.withNoTextScaling(child: child)
-                  : _WithTextScalar(child: child);
-            });
-          },
-          linesMargin: EdgeInsets.only(bottom: 8, top: 2)),
+        richTextBuilder: (span) {
+          return Builder(builder: (context) {
+            final shouldIgnoreTextScaler =
+                context.getInheritedWidgetOfExactType<_WithTextScalar>() !=
+                    null;
+
+            final child = Text.rich(
+              span,
+              textScaler:
+                  shouldIgnoreTextScaler ? TextScaler.noScaling : customScaler,
+            );
+
+            return shouldIgnoreTextScaler
+                ? child
+                : _WithTextScalar(child: child);
+          });
+        },
+        linesMargin: compact
+            ? EdgeInsets.zero
+            : const EdgeInsets.only(bottom: 8, top: 2),
+      ),
       data: text,
     );
   }

--- a/lib/widgets/scaled_markdown.dart
+++ b/lib/widgets/scaled_markdown.dart
@@ -5,11 +5,18 @@ import 'package:markdown_widget/markdown_widget.dart';
 // See: https://github.com/asjqkkkk/markdown_widget/issues/208
 class ScaledMarkdown extends StatelessWidget {
   final String data;
-  const ScaledMarkdown({super.key, required this.data});
+  final int? maxCharacters;
+  const ScaledMarkdown({super.key, required this.data, this.maxCharacters});
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    String text = data;
+
+    if (maxCharacters != null && text.length > maxCharacters!) {
+      text = "${text.substring(0, maxCharacters)}…";
+    }
+
     return MarkdownBlock(
       config: theme.brightness == Brightness.light
           ? MarkdownConfig.defaultConfig
@@ -27,7 +34,7 @@ class ScaledMarkdown extends StatelessWidget {
             });
           },
           linesMargin: EdgeInsets.only(bottom: 8, top: 2)),
-      data: data,
+      data: text,
     );
   }
 }


### PR DESCRIPTION
Return text previews to flashbacks without images. Improve scaling and clipping of text within entry previews.

Partially addresses #371