### PR TITLE
feat: respect system time format

### DIFF
--- a/lib/config_provider.dart
+++ b/lib/config_provider.dart
@@ -291,6 +291,7 @@ class ConfigProvider with ChangeNotifier {
   }
 
   bool is24HourFormat() {
+    if (PlatformDispatcher.instance.alwaysUse24HourFormat) return true;
     String formattedTime =
         DateFormat.jm(PlatformDispatcher.instance.locale.toString())
             .format(DateTime.now());

--- a/lib/flashback_manager.dart
+++ b/lib/flashback_manager.dart
@@ -6,7 +6,6 @@ import 'package:daily_you/l10n/generated/app_localizations.dart';
 import 'package:daily_you/models/entry.dart';
 import 'package:daily_you/models/flashback.dart';
 import 'package:daily_you/time_manager.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 class FlashbackManager {
@@ -136,7 +135,7 @@ class FlashbackManager {
         entryLabels: entries.length == 1
             ? [label]
             : entries
-                .map((e) => DateFormat.jm(locale).format(e.timeCreate))
+                .map((e) => TimeManager.localizedTimeFormat(locale).format(e.timeCreate))
                 .toList(),
       ));
     });

--- a/lib/pages/edit_entry_page.dart
+++ b/lib/pages/edit_entry_page.dart
@@ -271,7 +271,7 @@ class _AddEditEntryPageState extends State<AddEditEntryPage>
                                                         VisualDensity.compact,
                                                     padding: EdgeInsets.all(6)),
                                                 child: Text(
-                                                  DateFormat.jm(TimeManager
+                                                  TimeManager.localizedTimeFormat(TimeManager
                                                           .currentLocale(
                                                               context))
                                                       .format(entryDate!),

--- a/lib/pages/entry_view_page.dart
+++ b/lib/pages/entry_view_page.dart
@@ -110,7 +110,7 @@ class _EntryViewPageState extends State<EntryViewPage> {
                                 radius: BorderRadius.circular(4),
                               ),
                               Text(
-                                DateFormat.jm(
+                                TimeManager.localizedTimeFormat(
                                         TimeManager.currentLocale(context))
                                     .format(entry.timeCreate),
                                 style: TextStyle(
@@ -141,7 +141,7 @@ class _EntryViewPageState extends State<EntryViewPage> {
                 padding: const EdgeInsets.only(
                     left: 8, top: 4, bottom: 18, right: 8),
                 child: Text(
-                  "${AppLocalizations.of(context)!.lastModified}: ${DateFormat.yMMMEd(TimeManager.currentLocale(context)).format(entry.timeModified)} ${DateFormat.jm(TimeManager.currentLocale(context)).format(entry.timeModified)}",
+                  "${AppLocalizations.of(context)!.lastModified}: ${DateFormat.yMMMEd(TimeManager.currentLocale(context)).format(entry.timeModified)} ${TimeManager.localizedTimeFormat(TimeManager.currentLocale(context)).format(entry.timeModified)}",
                   style: TextStyle(fontSize: 12, color: theme.disabledColor),
                 ),
               ),

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -21,7 +21,6 @@ import 'package:daily_you/pages/entries_list_page.dart';
 import 'package:daily_you/pages/entry_timeline_page.dart';
 import 'package:daily_you/pages/edit_entry_page.dart';
 import 'package:flutter_expandable_fab/flutter_expandable_fab.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 class HomePage extends StatefulWidget {
@@ -239,7 +238,7 @@ class _HomePageState extends State<HomePage>
                               .reversed
                               .toList(),
                           labelBuilder: (e) =>
-                              DateFormat.jm(locale).format(e.timeCreate),
+                              TimeManager.localizedTimeFormat(locale).format(e.timeCreate),
                         ),
                       ));
                     } else {

--- a/lib/pages/image_view_page.dart
+++ b/lib/pages/image_view_page.dart
@@ -141,7 +141,7 @@ class _ImageViewPageState extends State<ImageViewPage> {
                     const SizedBox(height: 8),
                     _infoRow(
                       Icons.schedule_rounded,
-                      "${DateFormat.yMMMEd(TimeManager.currentLocale(context)).format(imageEntry.timeCreate)} ${DateFormat.jm(TimeManager.currentLocale(context)).format(imageEntry.timeCreate)}",
+                      "${DateFormat.yMMMEd(TimeManager.currentLocale(context)).format(imageEntry.timeCreate)} ${TimeManager.localizedTimeFormat(TimeManager.currentLocale(context)).format(imageEntry.timeCreate)}",
                     ),
                   ],
                 ),

--- a/lib/template_renderer.dart
+++ b/lib/template_renderer.dart
@@ -1,3 +1,4 @@
+import 'package:daily_you/time_manager.dart';
 import 'package:flutter/widgets.dart';
 import 'package:intl/intl.dart';
 import 'package:daily_you/l10n/generated/app_localizations.dart';
@@ -63,6 +64,6 @@ class TemplateRenderer {
       // Do nothing
     }
 
-    return DateFormat.jm(locale.toString()).format(dt);
+    return TimeManager.localizedTimeFormat(locale.toString()).format(dt);
   }
 }

--- a/lib/time_manager.dart
+++ b/lib/time_manager.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show PlatformDispatcher;
+
 import 'package:daily_you/config_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
@@ -75,8 +77,15 @@ class TimeManager {
   }
 
   static String timeOfDayString(BuildContext context, TimeOfDay timeOfDay) {
-    return DateFormat.jm(TimeManager.currentLocale(context))
+    return localizedTimeFormat(TimeManager.currentLocale(context))
         .format(addTimeOfDay(startOfDay(DateTime.now()), timeOfDay));
+  }
+
+  static DateFormat localizedTimeFormat(String locale) {
+    if (PlatformDispatcher.instance.alwaysUse24HourFormat) {
+      return DateFormat.Hm(locale);
+    }
+    return DateFormat.jm(locale);
   }
 
   static final Map<int, String> dayOfWeekIndexMapping = {

--- a/lib/widgets/entry_day_cell.dart
+++ b/lib/widgets/entry_day_cell.dart
@@ -74,7 +74,7 @@ class EntryDayCell extends StatelessWidget {
             .toList()
             .reversed
             .toList(),
-        labelBuilder: (e) => DateFormat.jm(locale).format(e.timeCreate),
+        labelBuilder: (e) => TimeManager.localizedTimeFormat(locale).format(e.timeCreate),
       ),
     ));
   }

--- a/lib/widgets/vertical_calendar.dart
+++ b/lib/widgets/vertical_calendar.dart
@@ -494,7 +494,7 @@ class _VerticalCalendarState extends State<VerticalCalendar>
             .toList()
             .reversed
             .toList(),
-        labelBuilder: (e) => DateFormat.jm(locale).format(e.timeCreate),
+        labelBuilder: (e) => TimeManager.localizedTimeFormat(locale).format(e.timeCreate),
       ),
     ));
   }


### PR DESCRIPTION
Time formatting respects the locale's region, but it does not respect the Android 24 hour time format override. Check the system setting and override to a 24 hour format when appropriate.

closes #390 