### PR TITLE
fix: map traditional chinese to a traditional locale region

### DIFF
--- a/lib/time_manager.dart
+++ b/lib/time_manager.dart
@@ -133,6 +133,11 @@ class TimeManager {
     if (platformLocale.languageCode == "oc") {
       return Locale("fr").toString();
     }
+    // Map zh_Hant to zh_TW which has Traditional Chinese data.
+    if (platformLocale.languageCode == "zh" &&
+        platformLocale.scriptCode == "Hant") {
+      return const Locale("zh", "TW").toString();
+    }
     return platformLocale.toString();
   }
 


### PR DESCRIPTION
System translations provided by Flutter were not respecting the _Hant subscript. Map this to a Chinese region that uses Traditional Chinese.

closes #406