### PR TITLE
feat: add calendar view options

### DIFF
--- a/lib/config_provider.dart
+++ b/lib/config_provider.dart
@@ -61,7 +61,7 @@ class ConfigKey {
   static const String hideImagesInFlashbacks = "hideImagesInFlashbacks";
   static const String lastDismissedSupportBannerDate =
       "lastDismissedSupportBannerDate";
-  static const String calendarFocusMode = "calendarFocusMode";
+  static const String calendarShowMood = "calendarShowMood";
   static const String calendarSystem = "calendarSystem";
   // Secure Configuration Values
   static const String requirePassword = "requirePassword";
@@ -72,6 +72,7 @@ class ConfigKey {
   static const String homePageViewMode = "homePageViewMode";
   static const String calendarViewMode = "calendarViewMode";
   static const String noMoodIcon = "noMoodIcon";
+  static const String calendarFocusMode = "calendarFocusMode";
 }
 
 class ImageQuality {
@@ -134,7 +135,7 @@ class ConfigProvider with ChangeNotifier {
     ConfigKey.hideImagesInCalendar: false,
     ConfigKey.hideImagesInFlashbacks: false,
     ConfigKey.lastDismissedSupportBannerDate: null,
-    ConfigKey.calendarFocusMode: 'images',
+    ConfigKey.calendarShowMood: true,
     ConfigKey.calendarSystem: 'system',
   };
 

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -1168,6 +1168,12 @@ abstract class AppLocalizations {
   /// **'consider supporting'**
   String get settingsConsiderSupporting;
 
+  /// No description provided for @imagesTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Images'**
+  String get imagesTitle;
+
   /// No description provided for @tagMoodTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_ar.dart
+++ b/lib/l10n/generated/app_localizations_ar.dart
@@ -617,5 +617,8 @@ class AppLocalizationsAr extends AppLocalizations {
   String get settingsConsiderSupporting => 'فكر في الدعم';
 
   @override
+  String get imagesTitle => 'Images';
+
+  @override
   String get tagMoodTitle => 'المزاج';
 }

--- a/lib/l10n/generated/app_localizations_be.dart
+++ b/lib/l10n/generated/app_localizations_be.dart
@@ -612,5 +612,8 @@ class AppLocalizationsBe extends AppLocalizations {
   String get settingsConsiderSupporting => 'consider supporting';
 
   @override
+  String get imagesTitle => 'Images';
+
+  @override
   String get tagMoodTitle => 'Mood';
 }

--- a/lib/l10n/generated/app_localizations_bg.dart
+++ b/lib/l10n/generated/app_localizations_bg.dart
@@ -612,5 +612,8 @@ class AppLocalizationsBg extends AppLocalizations {
   String get settingsConsiderSupporting => 'consider supporting';
 
   @override
+  String get imagesTitle => 'Images';
+
+  @override
   String get tagMoodTitle => 'Mood';
 }

--- a/lib/l10n/generated/app_localizations_cs.dart
+++ b/lib/l10n/generated/app_localizations_cs.dart
@@ -608,5 +608,8 @@ class AppLocalizationsCs extends AppLocalizations {
   String get settingsConsiderSupporting => 'zvažte podporu';
 
   @override
+  String get imagesTitle => 'Images';
+
+  @override
   String get tagMoodTitle => 'Nálada';
 }

--- a/lib/l10n/generated/app_localizations_da.dart
+++ b/lib/l10n/generated/app_localizations_da.dart
@@ -611,5 +611,8 @@ class AppLocalizationsDa extends AppLocalizations {
   String get settingsConsiderSupporting => 'overvej at støtte';
 
   @override
+  String get imagesTitle => 'Images';
+
+  @override
   String get tagMoodTitle => 'Humør';
 }

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -619,5 +619,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settingsConsiderSupporting => 'unterstützen';
 
   @override
+  String get imagesTitle => 'Images';
+
+  @override
   String get tagMoodTitle => 'Stimmung';
 }

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -612,5 +612,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settingsConsiderSupporting => 'consider supporting';
 
   @override
+  String get imagesTitle => 'Images';
+
+  @override
   String get tagMoodTitle => 'Mood';
 }

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -618,5 +618,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settingsConsiderSupporting => 'Considera en apoyar';
 
   @override
+  String get imagesTitle => 'Images';
+
+  @override
   String get tagMoodTitle => 'Ánimo';
 }

--- a/lib/l10n/generated/app_localizations_fa.dart
+++ b/lib/l10n/generated/app_localizations_fa.dart
@@ -611,5 +611,8 @@ class AppLocalizationsFa extends AppLocalizations {
   String get settingsConsiderSupporting => 'حمایت را در نظر بگیرید';
 
   @override
+  String get imagesTitle => 'Images';
+
+  @override
   String get tagMoodTitle => 'حس و حال';
 }

--- a/lib/l10n/generated/app_localizations_fi.dart
+++ b/lib/l10n/generated/app_localizations_fi.dart
@@ -618,5 +618,8 @@ class AppLocalizationsFi extends AppLocalizations {
   String get settingsConsiderSupporting => 'harkitse tukemista';
 
   @override
+  String get imagesTitle => 'Images';
+
+  @override
   String get tagMoodTitle => 'Mieliala';
 }

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -624,5 +624,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get settingsConsiderSupporting => 'pensez à soutenir';
 
   @override
+  String get imagesTitle => 'Images';
+
+  @override
   String get tagMoodTitle => 'Humeur';
 }

--- a/lib/l10n/generated/app_localizations_he.dart
+++ b/lib/l10n/generated/app_localizations_he.dart
@@ -610,5 +610,8 @@ class AppLocalizationsHe extends AppLocalizations {
   String get settingsConsiderSupporting => 'consider supporting';
 
   @override
+  String get imagesTitle => 'Images';
+
+  @override
   String get tagMoodTitle => 'Mood';
 }

--- a/lib/l10n/generated/app_localizations_hi.dart
+++ b/lib/l10n/generated/app_localizations_hi.dart
@@ -613,5 +613,8 @@ class AppLocalizationsHi extends AppLocalizations {
   String get settingsConsiderSupporting => 'consider supporting';
 
   @override
+  String get imagesTitle => 'Images';
+
+  @override
   String get tagMoodTitle => 'Mood';
 }

--- a/lib/l10n/generated/app_localizations_id.dart
+++ b/lib/l10n/generated/app_localizations_id.dart
@@ -613,5 +613,8 @@ class AppLocalizationsId extends AppLocalizations {
   String get settingsConsiderSupporting => 'pertimbangkan untuk mendukung';
 
   @override
+  String get imagesTitle => 'Images';
+
+  @override
   String get tagMoodTitle => 'Perasaan';
 }

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -622,5 +622,8 @@ class AppLocalizationsIt extends AppLocalizations {
       'Considera la possibilità di sostenere il progetto';
 
   @override
+  String get imagesTitle => 'Images';
+
+  @override
   String get tagMoodTitle => 'Stato d\'animo';
 }

--- a/lib/l10n/generated/app_localizations_ja.dart
+++ b/lib/l10n/generated/app_localizations_ja.dart
@@ -604,5 +604,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settingsConsiderSupporting => '支援の検討';
 
   @override
+  String get imagesTitle => 'Images';
+
+  @override
   String get tagMoodTitle => '気分';
 }

--- a/lib/l10n/generated/app_localizations_ko.dart
+++ b/lib/l10n/generated/app_localizations_ko.dart
@@ -604,5 +604,8 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settingsConsiderSupporting => '앱을 후원해주세요';
 
   @override
+  String get imagesTitle => 'Images';
+
+  @override
   String get tagMoodTitle => '기분';
 }

--- a/lib/l10n/generated/app_localizations_lt.dart
+++ b/lib/l10n/generated/app_localizations_lt.dart
@@ -630,5 +630,8 @@ class AppLocalizationsLt extends AppLocalizations {
   String get settingsConsiderSupporting => 'apsvarstykite galimybę paremti';
 
   @override
+  String get imagesTitle => 'Images';
+
+  @override
   String get tagMoodTitle => 'Nuotaika';
 }

--- a/lib/l10n/generated/app_localizations_ms.dart
+++ b/lib/l10n/generated/app_localizations_ms.dart
@@ -563,5 +563,8 @@ class AppLocalizationsMs extends AppLocalizations {
   String get settingsConsiderSupporting => 'pertimbangkan untuk menyokong';
 
   @override
+  String get imagesTitle => 'Images';
+
+  @override
   String get tagMoodTitle => 'Suasana';
 }

--- a/lib/l10n/generated/app_localizations_nb.dart
+++ b/lib/l10n/generated/app_localizations_nb.dart
@@ -612,5 +612,8 @@ class AppLocalizationsNb extends AppLocalizations {
   String get settingsConsiderSupporting => 'consider supporting';
 
   @override
+  String get imagesTitle => 'Images';
+
+  @override
   String get tagMoodTitle => 'Mood';
 }

--- a/lib/l10n/generated/app_localizations_nl.dart
+++ b/lib/l10n/generated/app_localizations_nl.dart
@@ -620,5 +620,8 @@ class AppLocalizationsNl extends AppLocalizations {
   String get settingsConsiderSupporting => 'overweeg te ondersteunen';
 
   @override
+  String get imagesTitle => 'Images';
+
+  @override
   String get tagMoodTitle => 'Humeur';
 }

--- a/lib/l10n/generated/app_localizations_oc.dart
+++ b/lib/l10n/generated/app_localizations_oc.dart
@@ -614,5 +614,8 @@ class AppLocalizationsOc extends AppLocalizations {
   String get settingsConsiderSupporting => 'consider supporting';
 
   @override
+  String get imagesTitle => 'Images';
+
+  @override
   String get tagMoodTitle => 'Umor';
 }

--- a/lib/l10n/generated/app_localizations_pl.dart
+++ b/lib/l10n/generated/app_localizations_pl.dart
@@ -618,5 +618,8 @@ class AppLocalizationsPl extends AppLocalizations {
   String get settingsConsiderSupporting => 'rozważ wsparcie';
 
   @override
+  String get imagesTitle => 'Images';
+
+  @override
   String get tagMoodTitle => 'Nastrój';
 }

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -616,6 +616,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get settingsConsiderSupporting => 'Considere Apoiar';
 
   @override
+  String get imagesTitle => 'Images';
+
+  @override
   String get tagMoodTitle => 'Humor';
 }
 

--- a/lib/l10n/generated/app_localizations_ro.dart
+++ b/lib/l10n/generated/app_localizations_ro.dart
@@ -613,5 +613,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get settingsConsiderSupporting => 'consider supporting';
 
   @override
+  String get imagesTitle => 'Images';
+
+  @override
   String get tagMoodTitle => 'Mood';
 }

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -622,5 +622,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settingsConsiderSupporting => 'подумайте о поддержке проекта';
 
   @override
+  String get imagesTitle => 'Images';
+
+  @override
   String get tagMoodTitle => 'Настроение';
 }

--- a/lib/l10n/generated/app_localizations_sv.dart
+++ b/lib/l10n/generated/app_localizations_sv.dart
@@ -612,5 +612,8 @@ class AppLocalizationsSv extends AppLocalizations {
   String get settingsConsiderSupporting => 'consider supporting';
 
   @override
+  String get imagesTitle => 'Images';
+
+  @override
   String get tagMoodTitle => 'Mood';
 }

--- a/lib/l10n/generated/app_localizations_ta.dart
+++ b/lib/l10n/generated/app_localizations_ta.dart
@@ -612,5 +612,8 @@ class AppLocalizationsTa extends AppLocalizations {
   String get settingsConsiderSupporting => 'consider supporting';
 
   @override
+  String get imagesTitle => 'Images';
+
+  @override
   String get tagMoodTitle => 'Mood';
 }

--- a/lib/l10n/generated/app_localizations_tr.dart
+++ b/lib/l10n/generated/app_localizations_tr.dart
@@ -612,5 +612,8 @@ class AppLocalizationsTr extends AppLocalizations {
   String get settingsConsiderSupporting => 'desteklemeyi düşünün';
 
   @override
+  String get imagesTitle => 'Images';
+
+  @override
   String get tagMoodTitle => 'Ruh hali';
 }

--- a/lib/l10n/generated/app_localizations_uk.dart
+++ b/lib/l10n/generated/app_localizations_uk.dart
@@ -620,5 +620,8 @@ class AppLocalizationsUk extends AppLocalizations {
   String get settingsConsiderSupporting => 'розглянути можливість підтримки';
 
   @override
+  String get imagesTitle => 'Images';
+
+  @override
   String get tagMoodTitle => 'Настрій';
 }

--- a/lib/l10n/generated/app_localizations_vi.dart
+++ b/lib/l10n/generated/app_localizations_vi.dart
@@ -613,5 +613,8 @@ class AppLocalizationsVi extends AppLocalizations {
   String get settingsConsiderSupporting => 'consider supporting';
 
   @override
+  String get imagesTitle => 'Images';
+
+  @override
   String get tagMoodTitle => 'Tâm trạng';
 }

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -602,6 +602,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settingsConsiderSupporting => '考虑支持';
 
   @override
+  String get imagesTitle => 'Images';
+
+  @override
   String get tagMoodTitle => '心情';
 }
 

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -335,6 +335,8 @@
   "@settingsMadeWithLove": {},
   "settingsConsiderSupporting": "consider supporting",
   "@settingsConsiderSupporting": {},
+  "imagesTitle": "Images",
+  "@imagesTitle": {},
   "tagMoodTitle": "Mood",
   "@tagMoodTitle": {}
 }

--- a/lib/widgets/entry_day_cell.dart
+++ b/lib/widgets/entry_day_cell.dart
@@ -21,7 +21,8 @@ class EntryDayCell extends StatelessWidget {
   final List<Entry> entries;
   final EntryImage? firstImage;
 
-  final bool isMoodFocus;
+  final bool showImages;
+  final bool showMood;
   final bool isJalali;
 
   const EntryDayCell({
@@ -32,7 +33,8 @@ class EntryDayCell extends StatelessWidget {
     required this.cellSize,
     required this.entries,
     required this.firstImage,
-    this.isMoodFocus = false,
+    this.showImages = true,
+    this.showMood = true,
     this.isJalali = false,
   });
 
@@ -170,7 +172,7 @@ class EntryDayCell extends StatelessWidget {
     final colorScheme = Theme.of(context).colorScheme;
 
     if (entries.isNotEmpty) {
-      final showImage = !isMoodFocus && firstImage != null;
+      final showImageBg = showImages && firstImage != null;
       return MergeSemantics(
           child: GestureDetector(
         onTap: () async {
@@ -199,14 +201,14 @@ class EntryDayCell extends StatelessWidget {
                   color: colorScheme.secondaryContainer,
                   borderRadius: BorderRadius.circular(8),
                 ),
-                clipBehavior: showImage ? Clip.hardEdge : Clip.none,
-                child: showImage
+                clipBehavior: showImageBg ? Clip.hardEdge : Clip.none,
+                child: showImageBg
                     ? LocalImageLoader(
                         imagePath: firstImage!.imgPath,
                         cacheSize: 100,
                       )
                     : Center(
-                        child: isMoodFocus && firstEntry?.mood != null
+                        child: !showImages && showMood && firstEntry?.mood != null
                             ? Container(
                                 width: 40,
                                 height: 40,
@@ -225,13 +227,11 @@ class EntryDayCell extends StatelessWidget {
                             : Text(
                                 '${isJalali ? TimeManager.jalaliDayNumber(date) : date.day}',
                                 style: TextStyle(
-                                    color: isMoodFocus
-                                        ? null
-                                        : colorScheme.onSecondaryContainer,
+                                    color: colorScheme.onSecondaryContainer,
                                     fontSize: 16)),
                       ),
               ),
-              if (showImage)
+              if (showImageBg)
                 ExcludeSemantics(
                   child: RawImage(
                     image: dayNumber,
@@ -242,7 +242,7 @@ class EntryDayCell extends StatelessWidget {
                 right: 0,
                 child: isMulti
                     ? _countBadge(context, entries.length)
-                    : !isMoodFocus && firstEntry!.mood != null
+                    : showImages && showMood && firstEntry!.mood != null
                         ? Container(
                             width: 23,
                             height: 23,

--- a/lib/widgets/vertical_calendar.dart
+++ b/lib/widgets/vertical_calendar.dart
@@ -1,6 +1,7 @@
 import 'dart:ui' as ui;
 
 import 'package:daily_you/config_provider.dart';
+import 'package:daily_you/l10n/generated/app_localizations.dart';
 import 'package:daily_you/models/entry.dart';
 import 'package:daily_you/pages/entries_list_page.dart';
 import 'package:daily_you/pages/entry_timeline_page.dart';
@@ -265,8 +266,7 @@ class _VerticalCalendarState extends State<VerticalCalendar>
 
       while (!weekIter.isBefore(firstWeekStart)) {
         final days = List<DateTime?>.generate(7, (i) {
-          final day =
-              DateTime(weekIter.year, weekIter.month, weekIter.day + i);
+          final day = DateTime(weekIter.year, weekIter.month, weekIter.day + i);
           final jDay = Jalali.fromDateTime(day);
           return (jDay.year == current.year && jDay.month == current.month)
               ? day
@@ -281,8 +281,7 @@ class _VerticalCalendarState extends State<VerticalCalendar>
 
         items.add(_WeekRowItem(days));
         offset += _weekRowHeight;
-        weekIter =
-            DateTime(weekIter.year, weekIter.month, weekIter.day - 7);
+        weekIter = DateTime(weekIter.year, weekIter.month, weekIter.day - 7);
       }
 
       items.add(_MonthHeaderItem(monthStart));
@@ -362,11 +361,9 @@ class _VerticalCalendarState extends State<VerticalCalendar>
     super.build(context);
     final configProvider = context.watch<ConfigProvider>();
     final firstDayIndex = configProvider.getFirstDayOfWeekIndex(context);
-    final hideImages =
-        configProvider.get(ConfigKey.hideImagesInCalendar) == true;
-    final isMoodFocus =
-        (configProvider.get(ConfigKey.calendarFocusMode) ?? 'images') ==
-            'moods';
+    final showImages =
+        configProvider.get(ConfigKey.hideImagesInCalendar) != true;
+    final showMood = configProvider.get(ConfigKey.calendarShowMood) != false;
     final entriesProvider = context.watch<EntriesProvider>();
     final imagesProvider = context.watch<EntryImagesProvider>();
 
@@ -412,9 +409,13 @@ class _VerticalCalendarState extends State<VerticalCalendar>
                         SliverFixedExtentList(
                           itemExtent: _weekRowHeight,
                           delegate: SliverChildBuilderDelegate(
-                            (context, index) => _buildItem(context, index,
-                                entriesProvider, imagesProvider, hideImages,
-                                isMoodFocus),
+                            (context, index) => _buildItem(
+                                context,
+                                index,
+                                entriesProvider,
+                                imagesProvider,
+                                showImages,
+                                showMood),
                             childCount: _items.length,
                           ),
                         ),
@@ -423,7 +424,7 @@ class _VerticalCalendarState extends State<VerticalCalendar>
                   ),
                 ],
               ),
-              _buildCalendarControls(context, isMoodFocus),
+              _buildCalendarControls(context, showImages, showMood),
               _buildJumpToTodayButton(context),
             ]);
       },
@@ -460,8 +461,10 @@ class _VerticalCalendarState extends State<VerticalCalendar>
     );
   }
 
-  Widget _buildCalendarControls(BuildContext context, bool isMoodFocus) {
+  Widget _buildCalendarControls(
+      BuildContext context, bool showImages, bool showMood) {
     final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context)!;
     return Row(
       children: [
         Padding(
@@ -487,18 +490,32 @@ class _VerticalCalendarState extends State<VerticalCalendar>
                   color: theme.colorScheme.primary,
                   padding: const EdgeInsets.all(8),
                 ),
-                IconButton(
-                  onPressed: () {
-                    context.read<ConfigProvider>().set(
-                          ConfigKey.calendarFocusMode,
-                          isMoodFocus ? 'images' : 'moods',
-                        );
-                  },
-                  icon: Icon(isMoodFocus
-                      ? Icons.image_rounded
-                      : Icons.mood_rounded),
-                  color: theme.colorScheme.primary,
+                PopupMenuButton<String>(
+                  icon: Icon(Icons.visibility_rounded,
+                      color: theme.colorScheme.primary),
                   padding: const EdgeInsets.all(8),
+                  shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(16)),
+                  itemBuilder: (context) => [
+                    CheckedPopupMenuItem<String>(
+                      value: 'images',
+                      checked: showImages,
+                      child: Text(l10n.imagesTitle),
+                    ),
+                    CheckedPopupMenuItem<String>(
+                      value: 'mood',
+                      checked: showMood,
+                      child: Text(l10n.tagMoodTitle),
+                    ),
+                  ],
+                  onSelected: (value) {
+                    final config = context.read<ConfigProvider>();
+                    if (value == 'images') {
+                      config.set(ConfigKey.hideImagesInCalendar, showImages);
+                    } else {
+                      config.set(ConfigKey.calendarShowMood, !showMood);
+                    }
+                  },
                 ),
               ],
             ),
@@ -564,7 +581,8 @@ class _VerticalCalendarState extends State<VerticalCalendar>
             .toList()
             .reversed
             .toList(),
-        labelBuilder: (e) => TimeManager.localizedTimeFormat(locale).format(e.timeCreate),
+        labelBuilder: (e) =>
+            TimeManager.localizedTimeFormat(locale).format(e.timeCreate),
       ),
     ));
   }
@@ -612,14 +630,18 @@ class _VerticalCalendarState extends State<VerticalCalendar>
     _jumpToMonth(selected);
   }
 
-  Widget _buildItem(BuildContext context, int index,
-      EntriesProvider entriesProvider, EntryImagesProvider imagesProvider,
-      bool hideImages, bool isMoodFocus) {
+  Widget _buildItem(
+      BuildContext context,
+      int index,
+      EntriesProvider entriesProvider,
+      EntryImagesProvider imagesProvider,
+      bool showImages,
+      bool showMood) {
     final item = _items[index];
     if (item is _MonthHeaderItem) return _buildMonthHeader(context, item.month);
     if (item is _WeekRowItem) {
-      return _buildWeekRow(context, item, entriesProvider, imagesProvider,
-          hideImages, isMoodFocus);
+      return _buildWeekRow(
+          context, item, entriesProvider, imagesProvider, showImages, showMood);
     }
     return const SizedBox.shrink();
   }
@@ -657,8 +679,8 @@ class _VerticalCalendarState extends State<VerticalCalendar>
       _WeekRowItem item,
       EntriesProvider entriesProvider,
       EntryImagesProvider imagesProvider,
-      bool hideImages,
-      bool isMoodFocus) {
+      bool showImages,
+      bool showMood) {
     return RepaintBoundary(
       child: _WeekRow(
         days: item.days,
@@ -667,8 +689,8 @@ class _VerticalCalendarState extends State<VerticalCalendar>
         dayNumberCache: _dayNumberCache,
         entriesProvider: entriesProvider,
         imagesProvider: imagesProvider,
-        hideImages: hideImages,
-        isMoodFocus: isMoodFocus,
+        showImages: showImages,
+        showMood: showMood,
         isJalali: _isJalali,
       ),
     );
@@ -682,8 +704,8 @@ class _WeekRow extends StatelessWidget {
   final Map<int, ui.Image> dayNumberCache;
   final EntriesProvider entriesProvider;
   final EntryImagesProvider imagesProvider;
-  final bool hideImages;
-  final bool isMoodFocus;
+  final bool showImages;
+  final bool showMood;
   final bool isJalali;
 
   const _WeekRow({
@@ -693,8 +715,8 @@ class _WeekRow extends StatelessWidget {
     required this.dayNumberCache,
     required this.entriesProvider,
     required this.imagesProvider,
-    required this.hideImages,
-    required this.isMoodFocus,
+    required this.showImages,
+    required this.showMood,
     this.isJalali = false,
   });
 
@@ -745,13 +767,12 @@ class _WeekRow extends StatelessWidget {
 
           final entries = entriesProvider.getEntriesForDate(day);
           final firstEntry = entries.firstOrNull;
-          final firstImage = hideImages || isMoodFocus || firstEntry == null
+          final firstImage = !showImages || firstEntry == null
               ? null
               : imagesProvider.getFirstImageForEntry(firstEntry.id!);
 
-          final displayDayNum = isJalali
-              ? TimeManager.jalaliDayNumber(day)
-              : day.day;
+          final displayDayNum =
+              isJalali ? TimeManager.jalaliDayNumber(day) : day.day;
 
           return SizedBox(
             width: cellSize,
@@ -763,7 +784,8 @@ class _WeekRow extends StatelessWidget {
               firstImage: firstImage,
               cellSize: cellSize,
               dayNumber: dayNumberCache[displayDayNum],
-              isMoodFocus: isMoodFocus,
+              showImages: showImages,
+              showMood: showMood,
               isJalali: isJalali,
             ),
           );


### PR DESCRIPTION
This replaces the mood focus mode. The user can toggle images and moods on and off independently. This allows for views like "image only". Custom additional tags or trackers could be added as view options.

closes #405 