### PR TITLE
feat: add tags to templates

### DIFF
--- a/lib/database/app_database.dart
+++ b/lib/database/app_database.dart
@@ -108,7 +108,7 @@ class AppDatabase {
 
   Future<void> open() async {
     _database = await openDatabase(_internalPath!,
-        version: 4, onCreate: _createDatabase, onUpgrade: _onUpgrade);
+        version: 5, onCreate: _createDatabase, onUpgrade: _onUpgrade);
 
     await EntriesProvider.instance.load();
     await EntryImagesProvider.instance.load();
@@ -331,6 +331,7 @@ CREATE TABLE $imagesTable (
 ''');
 
     await _createTagTables(db);
+    await _createTemplateTagTable(db);
     await TagsProvider.instance.createDefaultTags();
 
     await _createWelcomeEntry();
@@ -446,6 +447,19 @@ CREATE TABLE $entryTagsTable (
 ''');
   }
 
+  Future<void> _createTemplateTagTable(Database db) async {
+    await db.execute('''
+CREATE TABLE $templateTagsTable (
+    ${TemplateTagFields.id} INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    ${TemplateTagFields.templateId} INTEGER NOT NULL,
+    ${TemplateTagFields.tagId} INTEGER NOT NULL,
+    ${TemplateTagFields.timeCreate} DATETIME NOT NULL DEFAULT (DATETIME('now')),
+    FOREIGN KEY (${TemplateTagFields.templateId}) REFERENCES $templatesTable (id),
+    FOREIGN KEY (${TemplateTagFields.tagId}) REFERENCES $tagsTable (id)
+)
+''');
+  }
+
   void _onUpgrade(Database db, int oldVersion, int newVersion) async {
     _database = db;
     // In this case, oldVersion is 1, newVersion is 2
@@ -514,6 +528,9 @@ DROP TABLE old_entries;
     if (oldVersion <= 3) {
       await _createTagTables(db);
       await TagsProvider.instance.createDefaultTags();
+    }
+    if (oldVersion <= 4) {
+      await _createTemplateTagTable(db);
     }
   }
 }

--- a/lib/database/template_tag_dao.dart
+++ b/lib/database/template_tag_dao.dart
@@ -1,0 +1,43 @@
+import 'package:daily_you/database/app_database.dart';
+import 'package:daily_you/models/tag.dart';
+
+class TemplateTagDao {
+  static Future<List<TemplateTag>> getAll() async {
+    final db = AppDatabase.instance.database!;
+    final result = await db.query(templateTagsTable);
+    return result.map((json) => TemplateTag.fromJson(json)).toList();
+  }
+
+  static Future<TemplateTag> add(TemplateTag templateTag) async {
+    final db = AppDatabase.instance.database!;
+    final id = await db.insert(templateTagsTable, templateTag.toJson());
+    return templateTag.copy(id: id);
+  }
+
+  static Future<void> remove(int id) async {
+    final db = AppDatabase.instance.database!;
+    await db.delete(
+      templateTagsTable,
+      where: '${TemplateTagFields.id} = ?',
+      whereArgs: [id],
+    );
+  }
+
+  static Future<void> removeAllForTemplate(int templateId) async {
+    final db = AppDatabase.instance.database!;
+    await db.delete(
+      templateTagsTable,
+      where: '${TemplateTagFields.templateId} = ?',
+      whereArgs: [templateId],
+    );
+  }
+
+  static Future<void> removeAllForTag(int tagId) async {
+    final db = AppDatabase.instance.database!;
+    await db.delete(
+      templateTagsTable,
+      where: '${TemplateTagFields.tagId} = ?',
+      whereArgs: [tagId],
+    );
+  }
+}

--- a/lib/models/tag.dart
+++ b/lib/models/tag.dart
@@ -2,6 +2,7 @@ import 'package:daily_you/models/tag_icon_type.dart';
 
 const String tagsTable = 'tags';
 const String entryTagsTable = 'entry_tags';
+const String templateTagsTable = 'template_tags';
 
 enum TagType {
   label,
@@ -167,5 +168,55 @@ class EntryTag {
         EntryTagFields.tagId: tagId,
         EntryTagFields.value: value,
         EntryTagFields.timeCreate: timeCreate.toIso8601String(),
+      };
+}
+
+class TemplateTagFields {
+  static const List<String> values = [id, templateId, tagId, timeCreate];
+  static const String id = 'id';
+  static const String templateId = 'template_id';
+  static const String tagId = 'tag_id';
+  static const String timeCreate = 'time_create';
+}
+
+class TemplateTag {
+  final int? id;
+  final int templateId;
+  final int tagId;
+  final DateTime timeCreate;
+
+  const TemplateTag({
+    this.id,
+    required this.templateId,
+    required this.tagId,
+    required this.timeCreate,
+  });
+
+  TemplateTag copy({
+    int? id,
+    int? templateId,
+    int? tagId,
+    DateTime? timeCreate,
+  }) =>
+      TemplateTag(
+        id: id ?? this.id,
+        templateId: templateId ?? this.templateId,
+        tagId: tagId ?? this.tagId,
+        timeCreate: timeCreate ?? this.timeCreate,
+      );
+
+  static TemplateTag fromJson(Map<String, Object?> json) => TemplateTag(
+        id: json[TemplateTagFields.id] as int?,
+        templateId: json[TemplateTagFields.templateId] as int,
+        tagId: json[TemplateTagFields.tagId] as int,
+        timeCreate:
+            DateTime.parse(json[TemplateTagFields.timeCreate] as String),
+      );
+
+  Map<String, Object?> toJson() => {
+        TemplateTagFields.id: id,
+        TemplateTagFields.templateId: templateId,
+        TemplateTagFields.tagId: tagId,
+        TemplateTagFields.timeCreate: timeCreate.toIso8601String(),
       };
 }

--- a/lib/pages/edit_entry_page.dart
+++ b/lib/pages/edit_entry_page.dart
@@ -7,13 +7,15 @@ import 'package:daily_you/notification_manager.dart';
 import 'package:daily_you/models/tag.dart';
 import 'package:daily_you/providers/entries_provider.dart';
 import 'package:daily_you/providers/entry_images_provider.dart';
+import 'package:daily_you/models/template.dart';
 import 'package:daily_you/providers/tags_provider.dart';
 import 'package:daily_you/providers/templates_provider.dart';
-import 'package:daily_you/widgets/entry_tag_chips.dart';
+import 'package:daily_you/widgets/tag_attachment_source.dart';
+import 'package:daily_you/widgets/tag_grouped_chip_list.dart';
 import 'package:daily_you/widgets/tag_picker_dialog.dart';
 import 'package:daily_you/widgets/tag_chip.dart';
-import 'package:daily_you/widgets/tracker_value_dialog.dart';
 import 'package:daily_you/time_manager.dart';
+import 'package:provider/provider.dart';
 import 'package:daily_you/pages/full_screen_text_editor_page.dart';
 import 'package:daily_you/widgets/edit_toolbar.dart';
 import 'package:daily_you/widgets/entry_image_editable_list.dart';
@@ -64,6 +66,9 @@ class _AddEditEntryPageState extends State<AddEditEntryPage>
   bool _newEntry = false;
   bool _creatingNewEntry = false;
   Timer? _debounceTimer;
+  late TagAttachmentSource _tagSource;
+  // Tag ids seeded from the default template, or already on the entry
+  late Set<int> _seededTagIds;
 
   Future<void> _initEntry() async {
     if (widget.entry == null) {
@@ -73,9 +78,15 @@ class _AddEditEntryPageState extends State<AddEditEntryPage>
               : (widget.overrideCreateDate ?? DateTime.now());
       var text = "";
       final defaultTemplate = TemplatesProvider.instance.getDefaultTemplate();
+      final defaultTagIds = <int>[];
       if (defaultTemplate != null) {
         text = defaultTemplate.text ?? "";
+        defaultTagIds.addAll(TagsProvider.instance
+            .getTemplateTagsForTemplate(defaultTemplate.id!)
+            .map((templateTag) => templateTag.tagId));
       }
+      _tagSource = TagAttachmentSource(
+          supportsValues: true, initialTagIds: defaultTagIds);
       _entry = Entry(
         text: text,
         mood: null,
@@ -88,7 +99,11 @@ class _AddEditEntryPageState extends State<AddEditEntryPage>
     } else {
       _entry = widget.entry!;
       id = _entry.id ?? -1;
+      _tagSource = TagAttachmentSource.fromEntryTags(
+          TagsProvider.instance.getEntryTagsForEntry(id));
     }
+    _seededTagIds = _tagSource.attachedTagIds.toSet();
+    _tagSource.addListener(_onTagsChanged);
     _lastMood = _entry.mood;
     mood = _entry.mood;
     _lastEntryDate = _entry.timeCreate;
@@ -126,6 +141,8 @@ class _AddEditEntryPageState extends State<AddEditEntryPage>
     _textEditingController.dispose();
     _undoController.dispose();
     _debounceTimer?.cancel();
+    _tagSource.removeListener(_onTagsChanged);
+    _tagSource.dispose();
     super.dispose();
   }
 
@@ -261,6 +278,7 @@ class _AddEditEntryPageState extends State<AddEditEntryPage>
                       controller: _textEditingController,
                       undoController: _undoController,
                       focusNode: _focusNode,
+                      onTemplateInserted: _applyInsertedTemplateTags,
                       trailer: _buildTagsButton(context, theme),
                     ),
                   ),
@@ -306,28 +324,40 @@ class _AddEditEntryPageState extends State<AddEditEntryPage>
                       "save-entry", Duration(seconds: 5), () => _saveEntry());
                 }),
           ),
-          EntryTagChips(
-            entryId: id,
-            padding: const EdgeInsets.only(left: 8, right: 8, bottom: 8),
-            chipBuilder: (tag, entryTag) => TagChip(
-              tag: tag,
-              value: entryTag.value,
-              onTap: tag.tagType == TagType.tracker
-                  ? () async {
-                      final newValue = await showTrackerValueDialog(
-                          context, tag,
-                          initialValue: entryTag.value);
-                      if (newValue != null) {
-                        await TagsProvider.instance
-                            .updateEntryTag(entryTag.copy(value: newValue));
-                      }
-                    }
-                  : null,
-              onRemove: () => TagsProvider.instance.removeEntryTag(entryTag),
-            ),
-          )
+          _buildTagChips(),
         ],
       ),
+    );
+  }
+
+  Widget _buildTagChips() {
+    const padding = EdgeInsets.only(left: 8, right: 8, bottom: 8);
+    return ListenableBuilder(
+      listenable: _tagSource,
+      builder: (context, _) {
+        final attachedIds = _tagSource.attachedTagIds;
+        if (attachedIds.isEmpty) return const SizedBox.shrink();
+        final tagsProvider = Provider.of<TagsProvider>(context);
+        final attachedSet = attachedIds.toSet();
+        final tagPool = tagsProvider.tags
+            .where((tag) => attachedSet.contains(tag.id))
+            .toList();
+        final sections = tagsProvider.buildSections('', tagPool: tagPool);
+        return Padding(
+          padding: padding,
+          child: TagGroupedChipList(
+            sections: sections,
+            chipBuilder: (tag) => TagChip(
+              tag: tag,
+              value: _tagSource.valueFor(tag.id!),
+              onTap: tag.tagType == TagType.tracker
+                  ? () => _tagSource.editValue(context, tag)
+                  : null,
+              onRemove: () => _tagSource.detach(tag.id!),
+            ),
+          ),
+        );
+      },
     );
   }
 
@@ -396,17 +426,11 @@ class _AddEditEntryPageState extends State<AddEditEntryPage>
   Widget _buildTagsButton(BuildContext context, ThemeData theme) {
     return IconButton(
       onPressed: () async {
-        if (id == -1) {
-          await _saveEntry(forceCreate: true);
-        }
-        if (id == -1) return;
-        if (context.mounted) {
-          await showDialog(
-            context: context,
-            builder: (_) =>
-                TagPickerDialog(mode: TagPickerMode.addToEntry, entryId: id),
-          );
-        }
+        await showDialog(
+          context: context,
+          builder: (_) =>
+              TagPickerDialog(mode: TagPickerMode.attach, source: _tagSource),
+        );
       },
       icon: Icon(
         Icons.local_offer_rounded,
@@ -498,7 +522,7 @@ class _AddEditEntryPageState extends State<AddEditEntryPage>
     await _saveEntry();
   }
 
-  Future<void> _saveEntry({bool forceCreate = false}) async {
+  Future<void> _saveEntry() async {
     // Saving is guarded since quickly entering and exiting the app could trigger
     // multiple async saves.
     if (_savingEntry == false) {
@@ -515,11 +539,13 @@ class _AddEditEntryPageState extends State<AddEditEntryPage>
       final hasMoodChange = updatedEntry.mood != _lastMood;
       final hasDateChange = updatedEntry.timeCreate != _lastEntryDate;
 
+      final hasTagChange = _tagsExceedSeed();
+
       if (_newEntry) {
-        if (forceCreate ||
-            hasTextChange ||
+        if (hasTextChange ||
             hasMoodChange ||
             hasDateChange ||
+            hasTagChange ||
             _currentImages.isNotEmpty) {
           if (Platform.isAndroid &&
               TimeManager.isSameDay(DateTime.now(), updatedEntry.timeCreate)) {
@@ -531,6 +557,8 @@ class _AddEditEntryPageState extends State<AddEditEntryPage>
           _lastText = _entry.text;
           _lastMood = _entry.mood;
           _lastEntryDate = _entry.timeCreate;
+          await TagsProvider.instance
+              .setEntryTags(id, _tagSource.toEntryTags(id));
         }
       } else {
         if (hasTextChange || hasMoodChange || hasDateChange) {
@@ -543,6 +571,8 @@ class _AddEditEntryPageState extends State<AddEditEntryPage>
           _lastEntryDate = updatedEntry.timeCreate;
           await EntriesProvider.instance.update(updatedEntry);
         }
+        await TagsProvider.instance
+            .setEntryTags(id, _tagSource.toEntryTags(id));
       }
       // Images will update if they changed
       await _saveOrUpdateImage(id);
@@ -592,6 +622,30 @@ class _AddEditEntryPageState extends State<AddEditEntryPage>
     }
     if (mounted) {
       setState(() {});
+    }
+  }
+
+  void _onTagsChanged() {
+    EasyDebounce.debounce(
+        "save-entry", const Duration(seconds: 5), () => _saveEntry());
+  }
+
+  // Whether the working set holds anything beyond the seeded default tags
+  bool _tagsExceedSeed() {
+    for (final tagId in _tagSource.attachedTagIds) {
+      if (!_seededTagIds.contains(tagId)) return true;
+      if (_tagSource.valueFor(tagId) != null) return true;
+    }
+    return false;
+  }
+
+  void _applyInsertedTemplateTags(Template template) {
+    if (template.id == null) return;
+    final templateTagIds = TagsProvider.instance
+        .getTemplateTagsForTemplate(template.id!)
+        .map((templateTag) => templateTag.tagId);
+    for (final tagId in templateTagIds) {
+      _tagSource.addTagId(tagId);
     }
   }
 

--- a/lib/providers/tags_provider.dart
+++ b/lib/providers/tags_provider.dart
@@ -4,6 +4,7 @@ import 'package:daily_you/database/app_database.dart';
 import 'package:daily_you/database/entry_tag_dao.dart';
 import 'package:daily_you/database/tag_category_dao.dart';
 import 'package:daily_you/database/tag_dao.dart';
+import 'package:daily_you/database/template_tag_dao.dart';
 import 'package:daily_you/l10n/generated/app_localizations.dart';
 import 'package:daily_you/models/tag.dart';
 import 'package:daily_you/models/tag_category.dart';
@@ -31,6 +32,11 @@ class TagsProvider with ChangeNotifier {
 
   Map<int, List<EntryTag>> _entryTagsByEntry = const {};
 
+  List<TemplateTag> _templateTags = List.empty();
+  List<TemplateTag> get templateTags => _templateTags;
+
+  Map<int, List<TemplateTag>> _templateTagsByTemplate = const {};
+
   void _setEntryTags(List<EntryTag> updated) {
     _entryTags = updated;
     final grouped = <int, List<EntryTag>>{};
@@ -40,10 +46,20 @@ class TagsProvider with ChangeNotifier {
     _entryTagsByEntry = grouped;
   }
 
+  void _setTemplateTags(List<TemplateTag> updated) {
+    _templateTags = updated;
+    final grouped = <int, List<TemplateTag>>{};
+    for (final templateTag in updated) {
+      (grouped[templateTag.templateId] ??= []).add(templateTag);
+    }
+    _templateTagsByTemplate = grouped;
+  }
+
   Future<void> load() async {
     categories = await TagCategoryDao.getAll();
     tags = await TagDao.getAll();
     _setEntryTags(await EntryTagDao.getAll());
+    _setTemplateTags(await TemplateTagDao.getAll());
     notifyListeners();
   }
 
@@ -100,6 +116,10 @@ class TagsProvider with ChangeNotifier {
     await EntryTagDao.removeAllForTag(tag.id!);
     _setEntryTags(
         entryTags.where((entryTag) => entryTag.tagId != tag.id).toList());
+    await TemplateTagDao.removeAllForTag(tag.id!);
+    _setTemplateTags(templateTags
+        .where((templateTag) => templateTag.tagId != tag.id)
+        .toList());
     await TagDao.remove(tag.id!);
     tags = tags.where((existing) => existing.id != tag.id).toList();
     await AppDatabase.instance.updateExternalDatabase();
@@ -165,6 +185,107 @@ class TagsProvider with ChangeNotifier {
     return _entryTagsByEntry[entryId] ?? const [];
   }
 
+  /// Reconciles the tags stored for [entryId] with [desired], adding, removing,
+  /// and updating rows so the database matches.
+  Future<void> setEntryTags(int entryId, List<EntryTag> desired) async {
+    final current = getEntryTagsForEntry(entryId);
+    final currentByTag = {
+      for (final entryTag in current) entryTag.tagId: entryTag
+    };
+    final desiredByTag = {
+      for (final entryTag in desired) entryTag.tagId: entryTag
+    };
+    var changed = false;
+
+    for (final entryTag in current) {
+      if (!desiredByTag.containsKey(entryTag.tagId)) {
+        await EntryTagDao.remove(entryTag.id!);
+        changed = true;
+      }
+    }
+
+    final result = <EntryTag>[];
+    for (final wanted in desired) {
+      final existing = currentByTag[wanted.tagId];
+      if (existing == null) {
+        result.add(await EntryTagDao.add(EntryTag(
+          entryId: entryId,
+          tagId: wanted.tagId,
+          value: wanted.value,
+          timeCreate: wanted.timeCreate,
+        )));
+        changed = true;
+      } else if (existing.value != wanted.value) {
+        final updated = EntryTag(
+          id: existing.id,
+          entryId: entryId,
+          tagId: wanted.tagId,
+          value: wanted.value,
+          timeCreate: existing.timeCreate,
+        );
+        await EntryTagDao.update(updated);
+        result.add(updated);
+        changed = true;
+      } else {
+        result.add(existing);
+      }
+    }
+
+    if (!changed) return;
+
+    final retained =
+        entryTags.where((entryTag) => entryTag.entryId != entryId).toList();
+    _setEntryTags([...retained, ...result]);
+    await AppDatabase.instance.updateExternalDatabase();
+    notifyListeners();
+  }
+
+  /// Reconciles the tags stored for [templateId] with [tagIds], adding and
+  /// removing rows so the database matches.
+  Future<void> setTemplateTags(int templateId, List<int> tagIds) async {
+    final current = getTemplateTagsForTemplate(templateId);
+    final currentIds = current.map((templateTag) => templateTag.tagId).toSet();
+    final desiredIds = tagIds.toSet();
+
+    for (final templateTag in current) {
+      if (!desiredIds.contains(templateTag.tagId)) {
+        await TemplateTagDao.remove(templateTag.id!);
+      }
+    }
+
+    final added = <TemplateTag>[];
+    for (final tagId in tagIds) {
+      if (currentIds.contains(tagId)) continue;
+      added.add(await TemplateTagDao.add(TemplateTag(
+        templateId: templateId,
+        tagId: tagId,
+        timeCreate: DateTime.now(),
+      )));
+    }
+
+    final retained = templateTags
+        .where((templateTag) =>
+            templateTag.templateId != templateId ||
+            desiredIds.contains(templateTag.tagId))
+        .toList();
+    _setTemplateTags([...retained, ...added]);
+    await AppDatabase.instance.updateExternalDatabase();
+    notifyListeners();
+  }
+
+  Future<void> removeAllTemplateTagsForTemplate(int templateId) async {
+    await TemplateTagDao.removeAllForTemplate(templateId);
+    _setTemplateTags(templateTags
+        .where((templateTag) => templateTag.templateId != templateId)
+        .toList());
+    await AppDatabase.instance.updateExternalDatabase();
+    notifyListeners();
+  }
+
+  List<TemplateTag> getTemplateTagsForTemplate(int templateId) {
+    return _templateTagsByTemplate[templateId] ?? const [];
+  }
+
   int entryCountForTag(int tagId) {
     return entryTags
         .where((entryTag) => entryTag.tagId == tagId)
@@ -216,9 +337,14 @@ class TagsProvider with ChangeNotifier {
         tags.where((tag) => tag.categoryId == category.id).toList();
     for (final tag in affected) {
       await EntryTagDao.removeAllForTag(tag.id!);
+      await TemplateTagDao.removeAllForTag(tag.id!);
     }
     _setEntryTags(entryTags
         .where((entryTag) => !affected.any((tag) => tag.id == entryTag.tagId))
+        .toList());
+    _setTemplateTags(templateTags
+        .where((templateTag) =>
+            !affected.any((tag) => tag.id == templateTag.tagId))
         .toList());
     for (final tag in affected) {
       await TagDao.remove(tag.id!);

--- a/lib/providers/templates_provider.dart
+++ b/lib/providers/templates_provider.dart
@@ -4,6 +4,7 @@ import 'package:daily_you/l10n/generated/app_localizations.dart';
 import 'package:daily_you/database/app_database.dart';
 import 'package:daily_you/database/template_dao.dart';
 import 'package:daily_you/models/template.dart';
+import 'package:daily_you/providers/tags_provider.dart';
 import 'package:flutter/material.dart';
 
 class TemplatesProvider with ChangeNotifier {
@@ -21,15 +22,18 @@ class TemplatesProvider with ChangeNotifier {
 
   // CRUD operations
 
-  Future<void> add(Template template) async {
+  Future<Template> add(Template template) async {
     // Insert the template into the database so that it has an ID
     final templateWithId = await TemplateDao.add(template);
     templates.add(templateWithId);
     await AppDatabase.instance.updateExternalDatabase();
     notifyListeners();
+    return templateWithId;
   }
 
   Future<void> remove(Template template) async {
+    await TagsProvider.instance
+        .removeAllTemplateTagsForTemplate(template.id!);
     await TemplateDao.remove(template.id!);
     templates.removeWhere((x) => x.id == template.id);
     await AppDatabase.instance.updateExternalDatabase();

--- a/lib/widgets/edit_template.dart
+++ b/lib/widgets/edit_template.dart
@@ -1,11 +1,17 @@
 import 'package:daily_you/models/template.dart';
+import 'package:daily_you/providers/tags_provider.dart';
 import 'package:daily_you/providers/templates_provider.dart';
 import 'package:daily_you/widgets/edit_toolbar.dart';
 import 'package:daily_you/widgets/entry_text_edit.dart';
+import 'package:daily_you/widgets/tag_attachment_source.dart';
+import 'package:daily_you/widgets/tag_chip.dart';
+import 'package:daily_you/widgets/tag_grouped_chip_list.dart';
+import 'package:daily_you/widgets/tag_picker_dialog.dart';
 import 'package:daily_you/widgets/template_variable_button.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:daily_you/l10n/generated/app_localizations.dart';
+import 'package:provider/provider.dart';
 
 class EditTemplate extends StatefulWidget {
   final Template? template;
@@ -19,6 +25,7 @@ class EditTemplate extends StatefulWidget {
 class _EditTemplateState extends State<EditTemplate> {
   late TextEditingController _nameController;
   late String templateText;
+  late final TagAttachmentSource _tagSource;
   final FocusNode _focusNode = FocusNode();
   final TextEditingController _textEditingController = TextEditingController();
   final UndoHistoryController _undoController = UndoHistoryController();
@@ -32,6 +39,13 @@ class _EditTemplateState extends State<EditTemplate> {
     } else {
       templateText = "";
     }
+    final initialTagIds = widget.template?.id == null
+        ? <int>[]
+        : TagsProvider.instance
+            .getTemplateTagsForTemplate(widget.template!.id!)
+            .map((templateTag) => templateTag.tagId)
+            .toList();
+    _tagSource = TagAttachmentSource(initialTagIds: initialTagIds);
     _textEditingController
         .addListener(() => templateText = _textEditingController.text);
   }
@@ -39,6 +53,7 @@ class _EditTemplateState extends State<EditTemplate> {
   @override
   void dispose() {
     _nameController.dispose();
+    _tagSource.dispose();
     _focusNode.dispose();
     _textEditingController.dispose();
     _undoController.dispose();
@@ -46,19 +61,60 @@ class _EditTemplateState extends State<EditTemplate> {
   }
 
   Future<void> _saveTemplate() async {
+    final int templateId;
     if (widget.template == null) {
-      await TemplatesProvider.instance.add(Template(
+      final created = await TemplatesProvider.instance.add(Template(
           name: _nameController.text,
           text: templateText,
           timeCreate: DateTime.now(),
           timeModified: DateTime.now()));
+      templateId = created.id!;
     } else {
-      await TemplatesProvider.instance.update(widget.template!.copy(
+      final updated = widget.template!.copy(
           name: _nameController.text,
           text: templateText,
-          timeModified: DateTime.now()));
+          timeModified: DateTime.now());
+      await TemplatesProvider.instance.update(updated);
+      templateId = updated.id!;
     }
+    await TagsProvider.instance
+        .setTemplateTags(templateId, _tagSource.attachedTagIds);
+    if (!mounted) return;
     Navigator.of(context).pop();
+  }
+
+  Future<void> _openTagPicker() async {
+    await showDialog(
+      context: context,
+      builder: (_) =>
+          TagPickerDialog(mode: TagPickerMode.attach, source: _tagSource),
+    );
+  }
+
+  Widget _buildTagChips() {
+    return ListenableBuilder(
+      listenable: _tagSource,
+      builder: (context, _) {
+        final attachedIds = _tagSource.attachedTagIds;
+        if (attachedIds.isEmpty) return const SizedBox.shrink();
+        final tagsProvider = Provider.of<TagsProvider>(context);
+        final attachedSet = attachedIds.toSet();
+        final tagPool = tagsProvider.tags
+            .where((tag) => attachedSet.contains(tag.id))
+            .toList();
+        final sections = tagsProvider.buildSections('', tagPool: tagPool);
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(8, 8, 8, 0),
+          child: TagGroupedChipList(
+            sections: sections,
+            chipBuilder: (tag) => TagChip(
+              tag: tag,
+              onRemove: () => _tagSource.detach(tag.id!),
+            ),
+          ),
+        );
+      },
+    );
   }
 
   Widget saveButton() {
@@ -100,7 +156,8 @@ class _EditTemplateState extends State<EditTemplate> {
                               maxLines: 1,
                               textCapitalization: TextCapitalization.words,
                               spellCheckConfiguration: SpellCheckConfiguration(
-                                  spellCheckService: DefaultSpellCheckService()),
+                                  spellCheckService:
+                                      DefaultSpellCheckService()),
                               decoration: InputDecoration(
                                 border: InputBorder.none,
                                 hintText:
@@ -109,6 +166,18 @@ class _EditTemplateState extends State<EditTemplate> {
                             ),
                           ),
                         ),
+                      ),
+                    ),
+                  ),
+                ),
+                SliverToBoxAdapter(
+                  child: Align(
+                    alignment: Alignment.topCenter,
+                    child: ConstrainedBox(
+                      constraints: const BoxConstraints(maxWidth: 800),
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                        child: _buildTagChips(),
                       ),
                     ),
                   ),
@@ -160,8 +229,11 @@ class _EditTemplateState extends State<EditTemplate> {
               controller: _textEditingController,
               undoController: _undoController,
               focusNode: _focusNode,
-              trailer:
-                  TemplateVariableButton(controller: _textEditingController),
+              showTemplateButton: false,
+              trailer: TemplateVariableButton(
+                controller: _textEditingController,
+                onAddTags: _openTagPicker,
+              ),
             ),
           ),
         ],

--- a/lib/widgets/edit_toolbar.dart
+++ b/lib/widgets/edit_toolbar.dart
@@ -1,3 +1,4 @@
+import 'package:daily_you/models/template.dart';
 import 'package:daily_you/widgets/markdown_toolbar.dart';
 import 'package:flutter/material.dart';
 
@@ -8,12 +9,16 @@ class EditToolbar extends StatelessWidget {
     required this.undoController,
     required this.focusNode,
     this.trailer,
+    this.showTemplateButton = true,
+    this.onTemplateInserted,
   });
 
   final TextEditingController controller;
   final UndoHistoryController undoController;
   final FocusNode focusNode;
   final Widget? trailer;
+  final bool showTemplateButton;
+  final void Function(Template template)? onTemplateInserted;
 
   @override
   Widget build(BuildContext context) {
@@ -24,6 +29,8 @@ class EditToolbar extends StatelessWidget {
             controller: controller,
             focusNode: focusNode,
             undoController: undoController,
+            showTemplateButton: showTemplateButton,
+            onTemplateInserted: onTemplateInserted,
           ),
         ),
         if (trailer != null)

--- a/lib/widgets/markdown_toolbar.dart
+++ b/lib/widgets/markdown_toolbar.dart
@@ -1,4 +1,5 @@
 import 'package:daily_you/config_provider.dart';
+import 'package:daily_you/models/template.dart';
 import 'package:daily_you/widgets/template_select_popup.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -21,12 +22,16 @@ class MarkdownToolbar extends StatefulWidget {
   final TextEditingController controller;
   final FocusNode focusNode;
   final UndoHistoryController? undoController;
+  final bool showTemplateButton;
+  final void Function(Template template)? onTemplateInserted;
 
   const MarkdownToolbar({
     super.key,
     required this.controller,
     required this.focusNode,
     this.undoController,
+    this.showTemplateButton = true,
+    this.onTemplateInserted,
   });
 
   @override
@@ -210,19 +215,22 @@ class _MarkdownToolbarState extends State<MarkdownToolbar> {
     }
 
     // Template insert
-    entries.add(_ToolbarEntry(
-      width: _buttonWidth,
-      isDivider: false,
-      build: (ctx, closePopup) => IconButton(
-        padding: EdgeInsets.zero,
-        visualDensity: VisualDensity.compact,
-        icon: const Icon(Icons.note_add_rounded, size: 24),
-        onPressed: () {
-          closePopup?.call();
-          showTemplateSelectPopup(ctx, widget.controller);
-        },
-      ),
-    ));
+    if (widget.showTemplateButton) {
+      entries.add(_ToolbarEntry(
+        width: _buttonWidth,
+        isDivider: false,
+        build: (ctx, closePopup) => IconButton(
+          padding: EdgeInsets.zero,
+          visualDensity: VisualDensity.compact,
+          icon: const Icon(Icons.note_add_rounded, size: 24),
+          onPressed: () {
+            closePopup?.call();
+            showTemplateSelectPopup(ctx, widget.controller,
+                onTemplateSelected: widget.onTemplateInserted);
+          },
+        ),
+      ));
+    }
 
     // Markdown controls
     if (entries.isNotEmpty) addDivider();

--- a/lib/widgets/tag_attachment_source.dart
+++ b/lib/widgets/tag_attachment_source.dart
@@ -1,0 +1,82 @@
+import 'package:daily_you/models/tag.dart';
+import 'package:daily_you/widgets/tracker_value_dialog.dart';
+import 'package:flutter/widgets.dart';
+
+/// In-memory working set of attached tags. Holds tag ids and (optionally) tracker values
+class TagAttachmentSource extends ChangeNotifier {
+  /// Whether tracker values are prompted for and stored
+  final bool supportsValues;
+
+  final List<int> _tagIds;
+  final Map<int, String?> _values;
+
+  TagAttachmentSource({
+    this.supportsValues = false,
+    List<int> initialTagIds = const [],
+  })  : _tagIds = List.of(initialTagIds),
+        _values = {};
+
+  TagAttachmentSource.fromEntryTags(
+    List<EntryTag> entryTags, {
+    this.supportsValues = true,
+  })  : _tagIds = entryTags.map((entryTag) => entryTag.tagId).toList(),
+        _values = {
+          for (final entryTag in entryTags) entryTag.tagId: entryTag.value
+        };
+
+  List<int> get attachedTagIds => List.unmodifiable(_tagIds);
+
+  bool contains(int tagId) => _tagIds.contains(tagId);
+
+  /// Tracker value for [tagId], or null when unset or unsupported.
+  String? valueFor(int tagId) => supportsValues ? _values[tagId] : null;
+
+  /// Snapshots the working set as [EntryTag]s for [entryId], ready to persist.
+  List<EntryTag> toEntryTags(int entryId) => [
+        for (final tagId in _tagIds)
+          EntryTag(
+            entryId: entryId,
+            tagId: tagId,
+            value: supportsValues ? _values[tagId] : null,
+            timeCreate: DateTime.now(),
+          )
+      ];
+
+  /// Stages [tagId] directly without a value prompt
+  void addTagId(int tagId) {
+    if (_tagIds.contains(tagId)) return;
+    _tagIds.add(tagId);
+    notifyListeners();
+  }
+
+  /// Attaches [tag]. When [supportsValues] and the tag is a tracker, prompts for
+  /// a value; a cancelled prompt leaves the tag unattached.
+  Future<void> attach(BuildContext context, Tag tag) async {
+    if (_tagIds.contains(tag.id!)) return;
+    String? value;
+    if (supportsValues && tag.tagType == TagType.tracker) {
+      value = await showTrackerValueDialog(context, tag);
+      if (value == null) return;
+    }
+    _tagIds.add(tag.id!);
+    if (value != null) _values[tag.id!] = value;
+    notifyListeners();
+  }
+
+  /// Edits the tracker value of an already-attached [tag].
+  Future<void> editValue(BuildContext context, Tag tag) async {
+    if (!supportsValues) return;
+    final value = await showTrackerValueDialog(context, tag,
+        initialValue: _values[tag.id!]);
+    if (value == null) return;
+    _values[tag.id!] = value;
+    notifyListeners();
+  }
+
+  /// Removes the tag with [tagId].
+  Future<void> detach(int tagId) async {
+    _tagIds.remove(tagId);
+    _values.remove(tagId);
+    notifyListeners();
+  }
+}

--- a/lib/widgets/tag_picker_dialog.dart
+++ b/lib/widgets/tag_picker_dialog.dart
@@ -3,24 +3,23 @@ import 'package:daily_you/models/tag.dart';
 import 'package:daily_you/pages/settings/tags_settings.dart';
 import 'package:daily_you/providers/tags_provider.dart';
 import 'package:daily_you/widgets/edit_tag.dart';
-import 'package:daily_you/widgets/entry_tag_chips.dart';
+import 'package:daily_you/widgets/tag_attachment_source.dart';
 import 'package:daily_you/widgets/tag_chip.dart';
 import 'package:daily_you/widgets/tag_grouped_chip_list.dart';
-import 'package:daily_you/widgets/tracker_value_dialog.dart';
 import 'package:daily_you/utils/tag_name_sanitizer.dart';
 import 'package:flutter/material.dart';
 import 'package:daily_you/l10n/generated/app_localizations.dart';
 import 'package:provider/provider.dart';
 
-enum TagPickerMode { addToEntry, selectSingle, filter }
+enum TagPickerMode { attach, selectSingle, filter }
 
 enum TagFilterMode { all, any }
 
 class TagPickerDialog extends StatefulWidget {
   final TagPickerMode mode;
 
-  // addToEntry
-  final int? entryId;
+  // attach
+  final TagAttachmentSource? source;
 
   // filter
   final List<int> initialSelectedTagIds;
@@ -33,7 +32,7 @@ class TagPickerDialog extends StatefulWidget {
   const TagPickerDialog({
     super.key,
     required this.mode,
-    this.entryId,
+    this.source,
     this.initialSelectedTagIds = const [],
     this.initialFilterMode = TagFilterMode.any,
     this.initialNoTagsOnly = false,
@@ -80,34 +79,7 @@ class _TagPickerDialogState extends State<TagPickerDialog> {
     ConfigProvider.instance.set(ConfigKey.tagPickerSortMode, newMode);
   }
 
-  // addToEntry mode helpers
-
-  Future<void> _addLabelTag(TagsProvider provider, Tag tag) async {
-    await provider.addEntryTag(EntryTag(
-      entryId: widget.entryId!,
-      tagId: tag.id!,
-      timeCreate: DateTime.now(),
-    ));
-  }
-
-  Future<void> _addTrackerTag(TagsProvider provider, Tag tag) async {
-    final value = await showTrackerValueDialog(context, tag);
-    if (value == null) return;
-    await provider.addEntryTag(EntryTag(
-      entryId: widget.entryId!,
-      tagId: tag.id!,
-      value: value,
-      timeCreate: DateTime.now(),
-    ));
-  }
-
-  Future<void> _editTrackerValue(
-      TagsProvider provider, EntryTag entryTag, Tag tag) async {
-    final value = await showTrackerValueDialog(context, tag,
-        initialValue: entryTag.value);
-    if (value == null) return;
-    await provider.updateEntryTag(entryTag.copy(value: value));
-  }
+  // attach mode helpers
 
   Future<void> _createAndAddTagWithName(
       TagsProvider provider, String name) async {
@@ -124,17 +96,10 @@ class _TagPickerDialogState extends State<TagPickerDialog> {
 
     _searchController.clear();
 
-    if (widget.mode == TagPickerMode.addToEntry) {
-      final alreadyAdded = provider
-          .getEntryTagsForEntry(widget.entryId!)
-          .any((entryTag) => entryTag.tagId == newTag.id);
-      if (alreadyAdded) return;
-
-      if (newTag.tagType == TagType.tracker) {
-        if (context.mounted) await _addTrackerTag(provider, newTag);
-      } else {
-        await _addLabelTag(provider, newTag);
-      }
+    if (widget.mode == TagPickerMode.attach) {
+      final source = widget.source!;
+      if (source.contains(newTag.id!)) return;
+      if (mounted) await source.attach(context, newTag);
     }
   }
 
@@ -177,17 +142,26 @@ class _TagPickerDialogState extends State<TagPickerDialog> {
 
   // builders
 
-  Widget _buildAddedChips(TagsProvider provider) {
-    return EntryTagChips(
-      entryId: widget.entryId!,
+  Widget _buildAttachedChips(TagsProvider provider) {
+    final source = widget.source!;
+    final attachedIds = source.attachedTagIds;
+    if (attachedIds.isEmpty) return const SizedBox.shrink();
+    final attachedSet = attachedIds.toSet();
+    final tagPool =
+        provider.tags.where((tag) => attachedSet.contains(tag.id)).toList();
+    final sections = provider.buildSections('', tagPool: tagPool);
+    return Padding(
       padding: const EdgeInsets.only(bottom: 8),
-      chipBuilder: (tag, entryTag) => TagChip(
-        tag: tag,
-        value: entryTag.value,
-        onTap: tag.tagType == TagType.tracker
-            ? () => _editTrackerValue(provider, entryTag, tag)
-            : null,
-        onRemove: () => provider.removeEntryTag(entryTag),
+      child: TagGroupedChipList(
+        sections: sections,
+        chipBuilder: (tag) => TagChip(
+          tag: tag,
+          value: source.valueFor(tag.id!),
+          onTap: (source.supportsValues && tag.tagType == TagType.tracker)
+              ? () => source.editValue(context, tag)
+              : null,
+          onRemove: () => source.detach(tag.id!),
+        ),
       ),
     );
   }
@@ -258,7 +232,7 @@ class _TagPickerDialogState extends State<TagPickerDialog> {
 
   Widget _buildSearchField(AppLocalizations l10n, TagsProvider provider) {
     final showAdd = _searchText.isNotEmpty &&
-        widget.mode == TagPickerMode.addToEntry &&
+        widget.mode == TagPickerMode.attach &&
         !provider.tags
             .any((tag) => tag.name.toLowerCase() == _searchText.toLowerCase());
 
@@ -351,16 +325,25 @@ class _TagPickerDialogState extends State<TagPickerDialog> {
 
   @override
   Widget build(BuildContext context) {
+    final source = widget.source;
+    if (source != null) {
+      // Rebuild when source mutates
+      return ListenableBuilder(
+        listenable: source,
+        builder: (context, _) => _buildDialog(context),
+      );
+    }
+    return _buildDialog(context);
+  }
+
+  Widget _buildDialog(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     return Consumer<TagsProvider>(
       builder: (context, provider, _) {
-        // Available pool excludes tags already selected/added
+        // Available pool excludes tags already selected/attached
         final List<int> excludedIds;
-        if (widget.mode == TagPickerMode.addToEntry) {
-          excludedIds = provider
-              .getEntryTagsForEntry(widget.entryId!)
-              .map((entryTag) => entryTag.tagId)
-              .toList();
+        if (widget.mode == TagPickerMode.attach) {
+          excludedIds = widget.source!.attachedTagIds;
         } else if (widget.mode == TagPickerMode.filter) {
           excludedIds = _selectedTagIds;
         } else {
@@ -394,7 +377,7 @@ class _TagPickerDialogState extends State<TagPickerDialog> {
 
         final String title;
         switch (widget.mode) {
-          case TagPickerMode.addToEntry:
+          case TagPickerMode.attach:
             title = l10n.addTagsTitle;
           case TagPickerMode.selectSingle:
             title = l10n.selectTagTitle;
@@ -471,8 +454,8 @@ class _TagPickerDialogState extends State<TagPickerDialog> {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              if (widget.mode == TagPickerMode.addToEntry)
-                _buildAddedChips(provider),
+              if (widget.mode == TagPickerMode.attach)
+                _buildAttachedChips(provider),
               if (widget.mode == TagPickerMode.filter) ...[
                 _buildFilterSelectedChips(provider),
                 _buildFilterModeToggle(context),
@@ -484,12 +467,8 @@ class _TagPickerDialogState extends State<TagPickerDialog> {
                 chipBuilder: (tag) => TagChip(
                   tag: tag,
                   onTap: () async {
-                    if (widget.mode == TagPickerMode.addToEntry) {
-                      if (tag.tagType == TagType.tracker) {
-                        await _addTrackerTag(provider, tag);
-                      } else {
-                        await _addLabelTag(provider, tag);
-                      }
+                    if (widget.mode == TagPickerMode.attach) {
+                      await widget.source!.attach(context, tag);
                     } else {
                       _addFilterTag(tag.id!);
                     }
@@ -518,7 +497,7 @@ class _TagPickerDialogState extends State<TagPickerDialog> {
     );
 
     switch (widget.mode) {
-      case TagPickerMode.addToEntry:
+      case TagPickerMode.attach:
         return [manageTags, close];
       case TagPickerMode.selectSingle:
         return [close];

--- a/lib/widgets/template_select_popup.dart
+++ b/lib/widgets/template_select_popup.dart
@@ -4,7 +4,8 @@ import 'package:daily_you/widgets/template_select.dart';
 import 'package:flutter/material.dart';
 
 void showTemplateSelectPopup(
-    BuildContext context, TextEditingController controller) {
+    BuildContext context, TextEditingController controller,
+    {void Function(Template template)? onTemplateSelected}) {
   showDialog(
     context: context,
     builder: (BuildContext context) {
@@ -26,6 +27,7 @@ void showTemplateSelectPopup(
           } else {
             controller.text = templateText;
           }
+          onTemplateSelected?.call(template);
         },
       );
     },

--- a/lib/widgets/template_variable_button.dart
+++ b/lib/widgets/template_variable_button.dart
@@ -1,13 +1,18 @@
 import 'package:daily_you/template_renderer.dart';
 import 'package:flutter/material.dart';
+import 'package:daily_you/l10n/generated/app_localizations.dart';
 
 class TemplateVariableButton extends StatelessWidget {
   const TemplateVariableButton({
     super.key,
     required this.controller,
+    this.onAddTags,
   });
 
   final TextEditingController controller;
+
+  final VoidCallback? onAddTags;
+  static const String _addTagsAction = '__add_tags__';
 
   void _addVariableToText(BuildContext context, String variable) {
     if (controller.text.isNotEmpty) {
@@ -40,13 +45,25 @@ class TemplateVariableButton extends StatelessWidget {
       padding: const EdgeInsets.all(8),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
       onSelected: (String newValue) {
+        if (newValue == _addTagsAction) {
+          onAddTags?.call();
+          return;
+        }
         _addVariableToText(context, newValue);
       },
       itemBuilder: (BuildContext context) {
         final options = TemplateRenderer.getVariableList(context);
-        return options.map((TemplateVariable option) {
-          return PopupMenuItem(value: option.value, child: Text(option.label));
-        }).toList();
+        return [
+          ...options.map((TemplateVariable option) {
+            return PopupMenuItem(
+                value: option.value, child: Text(option.label));
+          }),
+          if (onAddTags != null)
+            PopupMenuItem(
+              value: _addTagsAction,
+              child: Text(AppLocalizations.of(context)!.settingsTagsTitle),
+            ),
+        ];
       },
     );
   }


### PR DESCRIPTION
Add the ability to attach tags to templates. These tags will be added to entries when the template is inserted. This also applies to default templates. Trackers attached to templates have no value such that the user can add a value when applied to an entry.

Addresses tags in templates from #430 