### PR TITLE
feat: add tag preview indicators

### DIFF
--- a/lib/widgets/entry_card_header_row.dart
+++ b/lib/widgets/entry_card_header_row.dart
@@ -1,0 +1,79 @@
+import 'package:daily_you/models/entry.dart';
+import 'package:daily_you/providers/tags_provider.dart';
+import 'package:daily_you/widgets/entry_tag_icon_preview.dart';
+import 'package:daily_you/widgets/mood_icon.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+class EntryCardHeaderRow extends StatelessWidget {
+  final Entry entry;
+  final String title;
+  final TextStyle? titleStyle;
+  final EdgeInsetsGeometry titlePadding;
+
+  static const double _tagIconSize = 18;
+  static const double _tagIconSpacing = 4;
+
+  static const double _moodReserve = 24;
+  static const double _segmentGap = 2;
+
+  const EntryCardHeaderRow({
+    super.key,
+    required this.entry,
+    required this.title,
+    this.titleStyle,
+    this.titlePadding = EdgeInsets.zero,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final tagsProvider = context.watch<TagsProvider>();
+    final hasTags = entry.id != null &&
+        tagsProvider.getEntryTagsForEntry(entry.id!).isNotEmpty;
+    final hasMood = MoodIcon.getMoodIcon(entry.mood).isNotEmpty;
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final moodReserve = _segmentGap + (hasMood ? _moodReserve : 0.0);
+        final minTagReserve = hasTags ? _tagIconSize + _segmentGap : 0.0;
+        final titleCap = (constraints.maxWidth - moodReserve - minTagReserve)
+            .clamp(0.0, constraints.maxWidth);
+
+        return Row(
+          children: [
+            ConstrainedBox(
+              constraints: BoxConstraints(maxWidth: titleCap),
+              child: Padding(
+                padding: titlePadding,
+                child: Text(
+                  title,
+                  maxLines: 1,
+                  softWrap: false,
+                  overflow: TextOverflow.fade,
+                  style: titleStyle,
+                ),
+              ),
+            ),
+            Expanded(
+              child: hasTags
+                  ? Align(
+                      alignment: AlignmentDirectional.centerEnd,
+                      child: EntryTagIconPreview(
+                        entryId: entry.id,
+                        iconSize: _tagIconSize,
+                        spacing: _tagIconSpacing,
+                      ),
+                    )
+                  : const SizedBox.shrink(),
+            ),
+            const SizedBox(width: _segmentGap),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 2.0),
+              child: MoodIcon(moodValue: entry.mood),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/widgets/entry_card_widget.dart
+++ b/lib/widgets/entry_card_widget.dart
@@ -1,11 +1,11 @@
 import 'package:daily_you/l10n/generated/app_localizations.dart';
 import 'package:daily_you/models/image.dart';
 import 'package:daily_you/time_manager.dart';
+import 'package:daily_you/widgets/entry_card_header_row.dart';
 import 'package:daily_you/widgets/image_grid.dart';
 import 'package:daily_you/widgets/scaled_markdown.dart';
 import 'package:flutter/material.dart';
 import 'package:daily_you/models/entry.dart';
-import 'package:daily_you/widgets/mood_icon.dart';
 
 class EntryCardWidget extends StatelessWidget {
   const EntryCardWidget(
@@ -76,28 +76,13 @@ class EntryCardWidget extends StatelessWidget {
                         ),
             ),
           ),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 4.0),
-                child: Text(
-                  title == null ? time : title!,
-                  style: TextStyle(
-                      color: theme.textTheme.labelSmall?.color,
-                      fontWeight: FontWeight.bold),
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 2.0),
-                child: Container(
-                  constraints: const BoxConstraints(minWidth: 16),
-                  child: MoodIcon(
-                    moodValue: entry.mood,
-                  ),
-                ),
-              ),
-            ],
+          EntryCardHeaderRow(
+            entry: entry,
+            title: title == null ? time : title!,
+            titlePadding: const EdgeInsets.symmetric(horizontal: 4.0),
+            titleStyle: TextStyle(
+                color: theme.textTheme.labelSmall?.color,
+                fontWeight: FontWeight.bold),
           ),
         ],
       ),

--- a/lib/widgets/entry_tag_icon_preview.dart
+++ b/lib/widgets/entry_tag_icon_preview.dart
@@ -1,0 +1,132 @@
+import 'package:daily_you/models/tag.dart';
+import 'package:daily_you/providers/tags_provider.dart';
+import 'package:daily_you/utils/tag_visuals.dart';
+import 'package:daily_you/widgets/tag_icon_glyph.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+class EntryTagIconPreview extends StatelessWidget {
+  final int? entryId;
+  final double iconSize;
+  final double spacing;
+
+  const EntryTagIconPreview({
+    super.key,
+    required this.entryId,
+    this.iconSize = 18,
+    this.spacing = 4,
+  });
+
+  String _glyphKey(Tag tag) {
+    final hasIcon = tag.icon != null && tag.icon!.isNotEmpty;
+    return hasIcon
+        ? '${tag.iconType.name}:${tag.icon}'
+        : 'fallback:${tag.typeIcon.codePoint}';
+  }
+
+  int _maxFittingIcons(double availableWidth) {
+    if (availableWidth < iconSize) return 0;
+    return 1 + ((availableWidth - iconSize) / (iconSize + spacing)).floor();
+  }
+
+  /// Fixed size slot of a tag icon or character
+  Widget _slot(Widget child) {
+    return SizedBox(
+      width: iconSize,
+      height: iconSize,
+      child: FittedBox(fit: BoxFit.scaleDown, child: child),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final id = entryId;
+    if (id == null) return const SizedBox.shrink();
+
+    return Consumer<TagsProvider>(
+      builder: (context, tagsProvider, _) {
+        final entryTags = tagsProvider.getEntryTagsForEntry(id);
+        if (entryTags.isEmpty) return const SizedBox.shrink();
+
+        final attachedTagIds =
+            entryTags.map((entryTag) => entryTag.tagId).toSet();
+        final attachedTags = tagsProvider.tags
+            .where((tag) => attachedTagIds.contains(tag.id))
+            .toList();
+        if (attachedTags.isEmpty) return const SizedBox.shrink();
+
+        final orderedTags = tagsProvider
+            .buildSections('', tagPool: attachedTags)
+            .expand((section) => section.tags)
+            .toList();
+
+        final colorScheme = Theme.of(context).colorScheme;
+        final seenKeys = <String>{};
+        final uniqueTags = <Tag>[];
+        final uniqueColors = <Color>[];
+        for (final tag in orderedTags) {
+          final color =
+              tag.resolvedColor(context, fallback: colorScheme.secondary);
+          if (seenKeys.add('${_glyphKey(tag)}|${color.toARGB32()}')) {
+            uniqueTags.add(tag);
+            uniqueColors.add(color);
+          }
+        }
+
+        return LayoutBuilder(
+          builder: (context, constraints) {
+            final fit = constraints.maxWidth.isFinite
+                ? _maxFittingIcons(constraints.maxWidth)
+                : uniqueTags.length;
+            if (fit <= 0) return const SizedBox.shrink();
+
+            final List<Widget> icons;
+            if (uniqueTags.length <= fit) {
+              // Full tags list
+              icons = [
+                for (var i = 0; i < uniqueTags.length; i++)
+                  _slot(TagIconGlyph(
+                    icon: uniqueTags[i].icon,
+                    iconType: uniqueTags[i].iconType,
+                    fallbackIcon: uniqueTags[i].typeIcon,
+                    color: uniqueColors[i],
+                    size: iconSize,
+                  )),
+              ];
+            } else if (fit == 1) {
+              // Tag presence indicator
+              icons = [
+                _slot(Icon(Icons.local_offer_rounded,
+                    size: iconSize, color: colorScheme.secondary)),
+              ];
+            } else {
+              // Additional tags indicator
+              icons = [
+                for (var i = 0; i < fit - 1; i++)
+                  _slot(TagIconGlyph(
+                    icon: uniqueTags[i].icon,
+                    iconType: uniqueTags[i].iconType,
+                    fallbackIcon: uniqueTags[i].typeIcon,
+                    color: uniqueColors[i],
+                    size: iconSize,
+                  )),
+                _slot(Icon(Icons.more_horiz_rounded,
+                    size: iconSize, color: colorScheme.secondary)),
+              ];
+            }
+
+            return Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                for (var i = 0; i < icons.length; i++) ...[
+                  if (i > 0) SizedBox(width: spacing),
+                  icons[i],
+                ],
+              ],
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/widgets/large_entry_card_widget.dart
+++ b/lib/widgets/large_entry_card_widget.dart
@@ -1,11 +1,11 @@
 import 'package:daily_you/models/image.dart';
 import 'package:daily_you/time_manager.dart';
+import 'package:daily_you/widgets/entry_card_header_row.dart';
 import 'package:daily_you/widgets/image_grid.dart';
 import 'package:daily_you/widgets/scaled_markdown.dart';
 import 'package:flutter/material.dart';
 import 'package:daily_you/l10n/generated/app_localizations.dart';
 import 'package:daily_you/models/entry.dart';
-import 'package:daily_you/widgets/mood_icon.dart';
 
 class LargeEntryCardWidget extends StatelessWidget {
   const LargeEntryCardWidget({
@@ -46,24 +46,14 @@ class LargeEntryCardWidget extends StatelessWidget {
               children: [
                 Padding(
                   padding: const EdgeInsets.all(2.0),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      Padding(
-                        padding: const EdgeInsets.only(left: 4.0),
-                        child: Text(
-                          title == null ? time : title!,
-                          style: TextStyle(
-                            color: theme.textTheme.labelSmall?.color,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                      ),
-                      Container(
-                        constraints: const BoxConstraints(minWidth: 16),
-                        child: MoodIcon(moodValue: entry.mood),
-                      ),
-                    ],
+                  child: EntryCardHeaderRow(
+                    entry: entry,
+                    title: title == null ? time : title!,
+                    titlePadding: const EdgeInsets.only(left: 4.0),
+                    titleStyle: TextStyle(
+                      color: theme.textTheme.labelSmall?.color,
+                      fontWeight: FontWeight.bold,
+                    ),
                   ),
                 ),
                 Expanded(


### PR DESCRIPTION
Add a tag preview to entry cards in the gallery and timeline pages.

closes #431 