### PR TITLE
fix: show the latest image in the calendar

### DIFF
--- a/lib/widgets/vertical_calendar.dart
+++ b/lib/widgets/vertical_calendar.dart
@@ -806,10 +806,12 @@ class _WeekRow extends StatelessWidget {
           }
 
           final entries = entriesProvider.getEntriesForDate(day);
-          final firstEntry = entries.firstOrNull;
-          final firstImage = !showImages || firstEntry == null
+          final firstImage = !showImages
               ? null
-              : imagesProvider.getFirstImageForEntry(firstEntry.id!);
+              : entries
+                  .map((entry) =>
+                      imagesProvider.getFirstImageForEntry(entry.id!))
+                  .firstWhere((image) => image != null, orElse: () => null);
 
           final displayDayNum =
               isJalali ? TimeManager.jalaliDayNumber(day) : day.day;


### PR DESCRIPTION
If multiple entries exist in a day, show the most recent image from any of the entries in the calendar cell (if any).

closes #442 